### PR TITLE
fix relative path for build pip package script

### DIFF
--- a/python/build-pip-package.sh
+++ b/python/build-pip-package.sh
@@ -41,7 +41,7 @@ DEST_DIR="$1"
 
 mkdir -p "${DEST_DIR}"
 
-DEST_DIR=$(cd "${DEST_DIR}" 2>/dev/null && pwd -P)
+DEST_DIR="$(cd "${DEST_DIR}" 2>/dev/null && pwd -P)"
 
 TMP_DIR="$(mktemp -d)"
 echo "Using temporary directory: ${TMP_DIR}"


### PR DESCRIPTION
readlink does not work on mac, use pwd

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/52)
<!-- Reviewable:end -->
