### PR TITLE
clean the condition inputs for the constants node

### DIFF
--- a/python/tensorflowjs/converters/tf_saved_model_conversion.py
+++ b/python/tensorflowjs/converters/tf_saved_model_conversion.py
@@ -131,10 +131,10 @@ def extract_weights(graph_def, output_graph):
       if not isinstance(value, np.ndarray):
         value = np.array(value)
 
-    const_manifest.append({'name': const.name, 'data': value})
+      const_manifest.append({'name': const.name, 'data': value})
 
-    # Remove the binary array from tensor and save it to the external file.
-    const.attr["value"].tensor.ClearField('tensor_content')
+      # Remove the binary array from tensor and save it to the external file.
+      const.attr["value"].tensor.ClearField('tensor_content')
 
   write_weights.write_weights([const_manifest], path)
 


### PR DESCRIPTION
for extracting constant from the graph def, we need to ignore the control inputs on the node.
They are created for runtime dependency, but it does not make sense for constants.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/58)
<!-- Reviewable:end -->
