### PR TITLE
Fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A 2-step process to import your model:
 
 Usage:
 ```bash
-$ tensorflowjs_coverter \
+$ tensorflowjs_converter \
     --input_format=tf_saved_model \
     --output_node_names='MobilenetV1/Predictions/Reshape_1' \
     --saved_model_tags=serve


### PR DESCRIPTION
I fixed README.md typo for usage command

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/64)
<!-- Reviewable:end -->
