### PR TITLE
Automate wheel build-test-push process

### DIFF
--- a/python/build-pip-package.sh
+++ b/python/build-pip-package.sh
@@ -34,10 +34,41 @@
 #                     exclusive with --upload.
 #   --confirm-upload: Do not prompt for yes/no before uploading to test or
 #                     prod PyPI. Use with care!
+#
+# N.B. For pypi/twine authentication, you need to have the file ~/.pypirc,
+#   with content formatted like below:
+# ```
+# [distutils]
+# index-servers =
+#     pypi-warehouse
+#     test-warehouse
+#
+# [test-warehouse]
+#     repository = https://test.pypi.org/legacy/
+#     username:<PYPIUSERNAME>
+#     password:<PYPIPWD>
+#
+# [pypi-warehouse]
+#     repository = https://upload.pypi.org/legacy/
+#     username:<PYPIUSERNAME>
+#     password:<PYPIPWD>
+# ````
 
 set -e
 
+function print_usage() {
+  echo "Usage:"
+  echo "  build-pip-packages.sh \\"
+  echo "      [--test] [--upload] [--upload-to-test] [--confirm-upload] <OUTPUT_DIR>"
+  echo
+}
+
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $# == 0 ]]; then
+  print_usage
+  exit 1
+fi
 
 RUN_TEST=0
 UPLOAD_TO_PROD_PYPI=0
@@ -56,10 +87,7 @@ while true; do
   elif [[ "$1" != --* ]]; then
     DEST_DIR="$1"
   else
-    echo "Usage:"
-    echo "  build-pip-packages.sh \\"
-    echo "      [--test] [--upload] [--upload-to-test] [--confirm-upload] <OUTPUT_DIR>"
-    echo
+    print_usage
     exit 1
   fi
   shift
@@ -69,26 +97,35 @@ while true; do
   fi
 done
 
-if [[ ${UPLOAD_TO_TEST_PYPI} == 1 && ${UPLOAD_TO_PROD_PYPI} == 1 ]]; then
+if [[ "${UPLOAD_TO_TEST_PYPI}" == 1 && "${UPLOAD_TO_PROD_PYPI}" == 1 ]]; then
   echo "ERROR: Do not use --upload and --upload-to-test together."
   exit 1
 fi
 
+if [[ "${UPLOAD_TO_PROD_PYPI}" == 1 || "${UPLOAD_TO_TEST_PYPI}" == 1 ]]; then
+  if [[ -z "$(which twine)" ]]; then
+    echo "ERROR: You intend to upload wheels to PyPI, but twine is not on path."
+    echo "  Do `pip install twine` first."
+    exit 1
+  fi
+fi
+
 if [[ -z "${DEST_DIR}" ]]; then
-  echo "Usage:"
-  echo "  build-pip-packages.sh \\"
-  echo "      [--test] [--upload] [--upload-to-test] [--confirm-upload] <OUTPUT_DIR>"
-  echo
+  print_usage
   exit 1
 fi
 
 # Test if we are currently in a virtualenv.
 echo 1
 REAL_PREFIX_OUT="$(python -c "import sys; print(hasattr(sys, 'real_prefix'))")"
-echo ${REAL_PREFIX_OUT}
 if [[ "${REAL_PREFIX_OUT}" == "True" ]]; then
   echo "ERROR: Do not run this script in a virtualenv."
   echo
+  exit 1
+fi
+
+if [[ -f "${DEST_DIR}" || -d "${DEST_DIR}" ]]; then
+  echo "ERROR: ${DEST_DIR} already exists. Please specify a new DEST_DIR."
   exit 1
 fi
 
@@ -143,70 +180,121 @@ fi
 # Create virtualenvs for python2 and python3; build (and test) the wheels inside
 # them.
 VENV_PYTHON_BINS="python2 python3"
-echo 21  # DEBUG
 for VENV_PYTHON_BIN in ${VENV_PYTHON_BINS}; do
-  echo "VENV_PYTHON_BIN = ${VENV_PYTHON_BIN}"   # DEBUG
+  if [[ -z "$(which "${VENV_PYTHON_BIN}")" ]]; then
+    echo "ERROR: Unable to find ${VENV_PYTHON_BIN} on path."
+    exit 1
+  fi
+
   TMP_VENV_DIR="$(mktemp -d)"
   virtualenv -p "${VENV_PYTHON_BIN}" "${TMP_VENV_DIR}"
   source "${TMP_VENV_DIR}/bin/activate"
+
+  pip install twine
+
+  echo
+  echo "Building wheel for ${VENV_PYTHON_BIN}: $(python --version 2>&1) ..."
+  echo
 
   pip install -r "${SCRIPTS_DIR}/requirements.txt"
 
   pushd "${TMP_DIR}" > /dev/null
   echo
 
-  echo "Building wheel for $(python --version)..."
+  echo "Building wheel for $(python --version 2>&1) ..."
   echo
-  
+
   python setup.py bdist_wheel
   WHEELS=$(ls dist/*.whl)
   mv dist/*.whl "${DEST_DIR}/"
 
+  WHEEL_PATH=""
+  echo
+  echo "Generated wheel file(s) in ${DEST_DIR} :"
+  for WHEEL in ${WHEELS}; do
+    WHEEL_BASE_NAME="$(basename "${WHEEL}")"
+    echo "  ${WHEEL_BASE_NAME}"
+    WHEEL_PATH="${DEST_DIR}/${WHEEL_BASE_NAME}"
+  done
+
+  # Run test on install.
+  if [[ "${RUN_TEST}" == "1" ]]; then
+    echo
+    echo "Running test-on-install for $(python --version 2>&1) ..."
+    echo
+
+    pip uninstall -y tensorflowjs || \
+      echo "It appears that tensorflowjs is not installed."
+
+    echo
+    echo "Installing tensorflowjs from wheel at path: ${WHEEL_PATH} ..."
+    echo
+
+    TEST_ON_INSTALL_DIR="$(mktemp -d)"
+
+    cp "${SCRIPTS_DIR}/test_pip_package.py" "${TEST_ON_INSTALL_DIR}"
+
+    pushd "${TEST_ON_INSTALL_DIR}" > /dev/null
+
+    pip install "${WHEEL_PATH}"
+    echo "Successfully installed ${WHEEL_PATH} for $(python --version 2>&1)."
+    echo
+
+    which pip  # DEBUG
+    which python  # DEBUG
+    pwd  # DEBUG
+    ls  # DEBUG
+    python test_pip_package.py
+
+    popd > /dev/null
+
+    rm -rf "${TEST_ON_INSTALL_DIR}"
+
+    echo
+    echo "Test-on-install for $(python --version 2>&1) PASSED."
+    echo
+    echo "Your pip wheel for $(python --version 2>&1) is at:"
+    echo "  ${WHEEL_PATH}"
+  fi
+
   popd > /dev/null
-  
+
   deactivate
   rm -rf "${TMP_VENV_DIR}"
 done
 
-exit 0   # DEBUG
+if [[ "${UPLOAD_TO_PROD_PYPI}" == 1 || "${UPLOAD_TO_TEST_PYPI}" == 1 ]]; then
+  if [[ "${UPLOAD_TO_PROD_PYPI}" == 1 ]]; then
+    UPLOAD_DEST="pypi-warehouse"
+  else
+    UPLOAD_DEST="test-warehouse"
+  fi
 
-WHEEL_PATH=""
-echo
-echo "Generated wheel file(s) in ${DEST_DIR} :"
-for WHEEL in ${WHEELS}; do
-  WHEEL_BASE_NAME="$(basename "${WHEEL}")"
-  echo "  ${WHEEL_BASE_NAME}"
-  WHEEL_PATH="${DEST_DIR}/${WHEEL_BASE_NAME}"
-done
-
-rm -rf "${TMP_DIR}"
-
-# Run test on install.
-if [[ "${RUN_TEST}" == "1" ]]; then
-  pip uninstall -y tensorflowjs || \
-    echo "It appears that tensorflowjs is not installed."
-
-  echo
-  echo "Installing tensorflowjs from wheel at path: ${WHEEL_PATH}..."
+  pushd "${DEST_DIR}" > /dev/null
+  echo "Found wheel files to upload to ${UPLOAD_DEST}:"
+  ls ./*.whl
   echo
 
-  pip install --force-reinstall "${WHEEL_PATH}"
+  TO_UPLOAD=0
+  if [[ "${CONFIRM_UPLOAD}" == 0 ]]; then
+    while true; do
+      read -r -p "Do you wish to proceed with the upload to ${UPLOAD_DEST}? (y/n): " yn
+        case $yn in
+          [Yy]* ) TO_UPLOAD=1; break;;
+          [Nn]* ) exit;;
+          * ) echo "Please answer y or n.";;
+        esac
+    done
+  else
+    TO_UPLOAD=1
+  fi
 
-  TEST_ON_INSTALL_DIR="$(mktemp -d)"
-
-  cp "${SCRIPTS_DIR}/test_pip_package.py" "${TEST_ON_INSTALL_DIR}"
-
-  pushd "${TEST_ON_INSTALL_DIR}" > /dev/null
-
-  python test_pip_package.py
+  if [[ "${TO_UPLOAD}" == 1 ]]; then
+    echo "Proceeding with the upload ..."
+    twine upload -r "${UPLOAD_DEST}" ./*.whl
+  fi
 
   popd > /dev/null
-
-  rm -rf "${TEST_ON_INSTALL_DIR}"
-
-  echo
-  echo "Test-on-install PASSED."
-  echo
-  echo "Your pip wheel is at:"
-  echo "  ${WHEEL_PATH}"
 fi
+
+rm -rf "${TMP_DIR}"

--- a/python/build-pip-package.sh
+++ b/python/build-pip-package.sh
@@ -52,7 +52,7 @@
 #     repository = https://upload.pypi.org/legacy/
 #     username:<PYPIUSERNAME>
 #     password:<PYPIPWD>
-# ````
+# ```
 
 set -e
 

--- a/python/build-pip-package.sh
+++ b/python/build-pip-package.sh
@@ -15,41 +15,90 @@
 # ==============================================================================
 
 # Build pip package for keras_model_converter.
+#
+# Run this script outside a virtualenv, as this script will activate virtualenvs
+# for python2 and python3 to generate the wheel files.
+#
+# Usage:
+#   build-pip-package.sh \
+#       [--test] [--upload] [--upload-to-test] [--confirm-upload] <DEST_DIR>
+#
+# Positional arguments:
+#   DEST_DIR: Destination directory for writing the pip wheels.
+#
+# Optional argumnets:
+#   --test: Test the pip packages by installing it (inside virtualenv)
+#           and running test_pip_package.py against the install.
+#   --upload:         Upload the py2 and py3 wheels to prod PyPI.
+#   --upload-to-test: Upload the py2 and py3 wheels to test PyPI, mutually
+#                     exclusive with --upload.
+#   --confirm-upload: Do not prompt for yes/no before uploading to test or
+#                     prod PyPI. Use with care!
+
 set -e
 
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if [[ $# -lt 1 ]]; then
+RUN_TEST=0
+UPLOAD_TO_PROD_PYPI=0
+UPLOAD_TO_TEST_PYPI=0
+CONFIRM_UPLOAD=0
+DEST_DIR=""
+while true; do
+  if [[ "$1" == "--test" ]]; then
+    RUN_TEST=1
+  elif [[ "$1" == "--upload" ]]; then
+    UPLOAD_TO_PROD_PYPI=1
+  elif [[ "$1" == "--upload-to-test" ]]; then
+    UPLOAD_TO_TEST_PYPI=1
+  elif [[ "$1" == "--confirm-upload" ]]; then
+    CONFIRM_UPLOAD=1
+  elif [[ "$1" != --* ]]; then
+    DEST_DIR="$1"
+  else
+    echo "Usage:"
+    echo "  build-pip-packages.sh \\"
+    echo "      [--test] [--upload] [--upload-to-test] [--confirm-upload] <OUTPUT_DIR>"
+    echo
+    exit 1
+  fi
+  shift
+
+  if [[ -z "$1" ]]; then
+    break
+  fi
+done
+
+if [[ ${UPLOAD_TO_TEST_PYPI} == 1 && ${UPLOAD_TO_PROD_PYPI} == 1 ]]; then
+  echo "ERROR: Do not use --upload and --upload-to-test together."
+  exit 1
+fi
+
+if [[ -z "${DEST_DIR}" ]]; then
   echo "Usage:"
-  echo "  build-pip-packages.sh [--test] <OUTPUT_DIR>"
-  echo
-  echo "Args:"
-  echo "  OUTPUT_DIR: Directory where the pip (.whl) file will be written."
-  echo "  --test:     Test the pip package by installing it and running"
-  echo "              test_pip_package.py against the install."
+  echo "  build-pip-packages.sh \\"
+  echo "      [--test] [--upload] [--upload-to-test] [--confirm-upload] <OUTPUT_DIR>"
   echo
   exit 1
 fi
 
-RUN_TEST=0
-if [[ "$1" == "--test" ]]; then
-  RUN_TEST=1
-  shift
+# Test if we are currently in a virtualenv.
+echo 1
+REAL_PREFIX_OUT="$(python -c "import sys; print(hasattr(sys, 'real_prefix'))")"
+echo ${REAL_PREFIX_OUT}
+if [[ "${REAL_PREFIX_OUT}" == "True" ]]; then
+  echo "ERROR: Do not run this script in a virtualenv."
+  echo
+  exit 1
 fi
 
-DEST_DIR="$1"
-
 mkdir -p "${DEST_DIR}"
-
 DEST_DIR="$(cd "${DEST_DIR}" 2>/dev/null && pwd -P)"
 
+# Copy all non-test .py files.
 TMP_DIR="$(mktemp -d)"
 echo "Using temporary directory: ${TMP_DIR}"
 
-pushd "${SCRIPTS_DIR}" > /dev/null
-echo
-
-# Copy all non-test .py files.
 PY_FILES=$(find . -name '*.py' ! -name '*_test.py')
 for PY_FILE in ${PY_FILES}; do
   echo "Copying ${PY_FILE}"
@@ -84,15 +133,42 @@ echo "Copying setup.cfg"
 cp "${SCRIPTS_DIR}/setup.cfg" "${TMP_DIR}/"
 
 echo
-popd
 
-pushd "${TMP_DIR}" > /dev/null
+# Check virtualenv is on path.
+if [[ -z "$(which virtualenv)" ]]; then
+  echo "ERROR: Cannot find virtualenv on path. Install virtualenv first."
+  exit 1
+fi
 
-python setup.py bdist_wheel
-WHEELS=$(ls dist/*.whl)
-mv dist/*.whl "${DEST_DIR}/"
+# Create virtualenvs for python2 and python3; build (and test) the wheels inside
+# them.
+VENV_PYTHON_BINS="python2 python3"
+echo 21  # DEBUG
+for VENV_PYTHON_BIN in ${VENV_PYTHON_BINS}; do
+  echo "VENV_PYTHON_BIN = ${VENV_PYTHON_BIN}"   # DEBUG
+  TMP_VENV_DIR="$(mktemp -d)"
+  virtualenv -p "${VENV_PYTHON_BIN}" "${TMP_VENV_DIR}"
+  source "${TMP_VENV_DIR}/bin/activate"
 
-popd > /dev/null
+  pip install -r "${SCRIPTS_DIR}/requirements.txt"
+
+  pushd "${TMP_DIR}" > /dev/null
+  echo
+
+  echo "Building wheel for $(python --version)..."
+  echo
+  
+  python setup.py bdist_wheel
+  WHEELS=$(ls dist/*.whl)
+  mv dist/*.whl "${DEST_DIR}/"
+
+  popd > /dev/null
+  
+  deactivate
+  rm -rf "${TMP_VENV_DIR}"
+done
+
+exit 0   # DEBUG
 
 WHEEL_PATH=""
 echo

--- a/python/build-pip-package.sh
+++ b/python/build-pip-package.sh
@@ -105,7 +105,7 @@ fi
 if [[ "${UPLOAD_TO_PROD_PYPI}" == 1 || "${UPLOAD_TO_TEST_PYPI}" == 1 ]]; then
   if [[ -z "$(which twine)" ]]; then
     echo "ERROR: You intend to upload wheels to PyPI, but twine is not on path."
-    echo "  Do `pip install twine` first."
+    echo "  Do: pip install twine"
     exit 1
   fi
 fi

--- a/python/build-pip-package.sh
+++ b/python/build-pip-package.sh
@@ -240,10 +240,6 @@ for VENV_PYTHON_BIN in ${VENV_PYTHON_BINS}; do
     echo "Successfully installed ${WHEEL_PATH} for $(python --version 2>&1)."
     echo
 
-    which pip  # DEBUG
-    which python  # DEBUG
-    pwd  # DEBUG
-    ls  # DEBUG
     python test_pip_package.py
 
     popd > /dev/null

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,4 +2,4 @@ h5py==2.7.1
 keras==2.1.4
 numpy==1.14.1
 six==1.11.0
-tensorflow==1.6.0
+tensorflow==1.7.0


### PR DESCRIPTION
Add upload feature to build-pip-package.sh
    
* The build-pip-package.sh now takes care of py2 and py3 in one command
* The script also provides a flag (--upload) with which it can upload
  built py2 and py3 wheels to PyPI using twine.
* Upgrade build/test tensorflow dependency to 1.7.0.
    
Usage example:
```sh
cd python
./build-pip-package.sh --test --upload /tmp/tfjs_pips
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/73)
<!-- Reviewable:end -->
