### PR TITLE
Add support for neg op in basic math executor

### DIFF
--- a/src/operations/executors/basic_math_executor.ts
+++ b/src/operations/executors/basic_math_executor.ts
@@ -61,6 +61,9 @@ export let executeOp: OpExecutor = (node: Node, tensorMap: NamedTensorsMap,
     case 'log':
       return [tfc.log(
           getParamValue('x', node, tensorMap, context) as tfc.Tensor)];
+    case 'neg':
+      return [tfc.neg(
+          getParamValue('x', node, tensorMap, context) as tfc.Tensor)];
     case 'relu':
       return [tfc.relu(
           getParamValue('x', node, tensorMap, context) as tfc.Tensor)];

--- a/src/operations/executors/basic_math_executor_test.ts
+++ b/src/operations/executors/basic_math_executor_test.ts
@@ -41,7 +41,7 @@ describe('basic math', () => {
 
   describe('executeOp', () => {
     ['abs', 'acos', 'asin', 'atan', 'ceil', 'cos', 'cosh', 'elu', 'exp',
-     'floor', 'log', 'relu', 'selu', 'sigmoid', 'sin', 'sinh', 'sqrt', 'square',
+     'floor', 'log', 'neg', 'relu', 'selu', 'sigmoid', 'sin', 'sinh', 'sqrt', 'square',
      'tanh', 'tan']
         .forEach(op => {
           it('should call tfc.' + op, () => {

--- a/src/operations/executors/basic_math_executor_test.ts
+++ b/src/operations/executors/basic_math_executor_test.ts
@@ -41,8 +41,8 @@ describe('basic math', () => {
 
   describe('executeOp', () => {
     ['abs', 'acos', 'asin', 'atan', 'ceil', 'cos', 'cosh', 'elu', 'exp',
-     'floor', 'log', 'neg', 'relu', 'selu', 'sigmoid', 'sin', 'sinh', 'sqrt', 'square',
-     'tanh', 'tan']
+     'floor', 'log', 'neg', 'relu', 'selu', 'sigmoid', 'sin', 'sinh', 'sqrt', 
+     'square', 'tanh', 'tan']
         .forEach(op => {
           it('should call tfc.' + op, () => {
             const spy = spyOn(tfc, op as 'abs');


### PR DESCRIPTION
Currently, executing models loaded via loadFrozenModel that contain "neg" nodes results in the error `Node type "neg" is not implemented`.

This branch adds support for "neg" nodes in the executeOp function to fix this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/90)
<!-- Reviewable:end -->
