### PR TITLE
Support deprecated param name

### DIFF
--- a/src/operations/operation_mapper.ts
+++ b/src/operations/operation_mapper.ts
@@ -26,6 +26,7 @@ import * as control from './op_list/control.json';
 import * as convolution from './op_list/convolution.json';
 import * as creation from './op_list/creation.json';
 import * as graph from './op_list/graph.json';
+import * as image from './op_list/image.json';
 import * as logical from './op_list/logical.json';
 import * as matrices from './op_list/matrices.json';
 import * as normalization from './op_list/normalization.json';
@@ -51,8 +52,8 @@ export class OperationMapper {
       ...(arithmetic as {}) as OpMapper[], ...(basicMath as {}) as OpMapper[],
       ...(control as {}) as OpMapper[], ...(convolution as {}) as OpMapper[],
       ...(creation as {}) as OpMapper[], ...(logical as {}) as OpMapper[],
-      ...(graph as {}) as OpMapper[], ...(matrices as {}) as OpMapper[],
-      ...(normalization as {}) as OpMapper[],
+      ...(image as {}) as OpMapper[], ...(graph as {}) as OpMapper[],
+      ...(matrices as {}) as OpMapper[], ...(normalization as {}) as OpMapper[],
       ...(reduction as {}) as OpMapper[], ...(sliceJoin as {}) as OpMapper[],
       ...(transformation as {}) as OpMapper[]
     ];

--- a/src/operations/operation_mapper.ts
+++ b/src/operations/operation_mapper.ts
@@ -133,7 +133,8 @@ export class OperationMapper {
 
               if (value === undefined && !!param.tfParamNameDeprecated) {
                 value = this.getStringParam(
-                    node.attr, param.tfParamName, param.defaultValue as string);
+                    node.attr, param.tfParamNameDeprecated,
+                    param.defaultValue as string);
               }
               break;
             case 'number':

--- a/src/operations/operation_mapper.ts
+++ b/src/operations/operation_mapper.ts
@@ -130,26 +130,56 @@ export class OperationMapper {
             case 'string':
               value = this.getStringParam(
                   node.attr, param.tfParamName, param.defaultValue as string);
+
+              if (value === undefined && !!param.tfParamNameDeprecated) {
+                value = this.getStringParam(
+                    node.attr, param.tfParamName, param.defaultValue as string);
+              }
               break;
             case 'number':
               value = this.getNumberParam(
                   node.attr, param.tfParamName, param.defaultValue as number);
+              if (value === undefined && !!param.tfParamNameDeprecated) {
+                value = this.getNumberParam(
+                    node.attr, param.tfParamNameDeprecated,
+                    param.defaultValue as number);
+              }
               break;
             case 'number[]':
               value = this.getNumericArrayParam(
                   node.attr, param.tfParamName, param.defaultValue as number[]);
+              if (value === undefined && !!param.tfParamNameDeprecated) {
+                value = this.getNumericArrayParam(
+                    node.attr, param.tfParamNameDeprecated,
+                    param.defaultValue as number[]);
+              }
               break;
             case 'bool':
               value = this.getBoolParam(
                   node.attr, param.tfParamName, param.defaultValue as boolean);
+              if (value === undefined && !!param.tfParamNameDeprecated) {
+                value = this.getBoolParam(
+                    node.attr, param.tfParamNameDeprecated,
+                    param.defaultValue as boolean);
+              }
               break;
             case 'shape':
               value = this.getTensorShapeParam(
                   node.attr, param.tfParamName, param.defaultValue as number[]);
+              if (value === undefined && !!param.tfParamNameDeprecated) {
+                value = this.getTensorShapeParam(
+                    node.attr, param.tfParamNameDeprecated,
+                    param.defaultValue as number[]);
+              }
               break;
             case 'dtype':
               value = this.getDtypeParam(
                   node.attr, param.tfParamName, param.defaultValue as DataType);
+              if (value === undefined && !!param.tfParamNameDeprecated) {
+                value = this.getDtypeParam(
+                    node.attr, param.tfParamNameDeprecated,
+                    param.defaultValue as DataType);
+              }
               break;
             case 'tensor':
             case 'tensors':
@@ -224,7 +254,8 @@ export class OperationMapper {
       def: number[]): number[] {
     const param = attrs[name];
     if (param) {
-      return (param.list.f.length ? param.list.f : param.list.i) as number[];
+      return (param.list.f && param.list.f.length ? param.list.f :
+                                                    param.list.i) as number[];
     }
     return def;
   }

--- a/src/operations/operation_mapper_test.ts
+++ b/src/operations/operation_mapper_test.ts
@@ -86,6 +86,12 @@ const SIMPLE_MODEL: tensorflow.IGraphDef = {
         T: {type: tensorflow.DataType.DT_FLOAT},
         dataFormat: {s: Uint8Array.from([1, 2, 34])}
       }
+    },
+    {
+      name: 'Squeeze',
+      op: 'Squeeze',
+      input: ['BiasAdd'],
+      attr: {squeeze_dims: {list: {i: [1, 2]}}}
     }
   ],
   versions: {producer: 1.0}
@@ -107,14 +113,14 @@ describe('operationMapper', () => {
 
       it('should find the graph output nodes', () => {
         expect(graph.outputs.map(node => node.name)).toEqual([
-          'Fill', 'BiasAdd'
+          'Fill', 'Squeeze'
         ]);
       });
 
       it('should convert nodes', () => {
         expect(Object.keys(graph.nodes)).toEqual([
           'image_placeholder', 'Const', 'Shape', 'Value', 'Fill', 'Conv2D',
-          'BiasAdd'
+          'BiasAdd', 'Squeeze'
         ]);
       });
     });
@@ -142,6 +148,10 @@ describe('operationMapper', () => {
         expect(graph.nodes['Conv2D'].params['pad'].value).toEqual('valid');
         expect(graph.nodes['Conv2D'].params['useCudnnOnGpu'].value)
             .toEqual(true);
+      });
+
+      it('should map params with deprecated name', () => {
+        expect(graph.nodes['Squeeze'].params['axis'].value).toEqual([1, 2]);
       });
     });
   });


### PR DESCRIPTION
looks like grappler is right to remove the reshape node, the issue is the model is using
deprecated param name for squeeze op.

fixes tensorflow/tfjs#85

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/92)
<!-- Reviewable:end -->
