### PR TITLE
Add support for SquaredDifference and StopGradient ops

### DIFF
--- a/src/operations/executors/arithmetic_executor.ts
+++ b/src/operations/executors/arithmetic_executor.ts
@@ -62,6 +62,11 @@ export let executeOp: OpExecutor =
               getParamValue('a', node, tensorMap, context) as tfc.Tensor,
               getParamValue('b', node, tensorMap, context) as tfc.Tensor)];
         }
+        case 'squaredDifference': {
+          return [tfc.squaredDifference(
+              getParamValue('a', node, tensorMap, context) as tfc.Tensor,
+              getParamValue('b', node, tensorMap, context) as tfc.Tensor)];
+        }
         default:
           throw TypeError(`Node type ${node.op} is not implemented`);
       }

--- a/src/operations/executors/arithmetic_executor_test.ts
+++ b/src/operations/executors/arithmetic_executor_test.ts
@@ -41,14 +41,16 @@ describe('arithmetic', () => {
   });
 
   describe('executeOp', () => {
-    ['add', 'mul', 'div', 'sub', 'maximum', 'minimum', 'pow'].forEach((op => {
-      it('should call tfc.' + op, () => {
-        const spy = spyOn(tfc, op as 'add');
-        node.op = op;
-        executeOp(node, {input1, input2}, context);
+    ['add', 'mul', 'div', 'sub', 'maximum', 'minimum', 'pow',
+     'squaredDifference']
+        .forEach((op => {
+          it('should call tfc.' + op, () => {
+            const spy = spyOn(tfc, op as 'add');
+            node.op = op;
+            executeOp(node, {input1, input2}, context);
 
-        expect(spy).toHaveBeenCalledWith(input1[0], input2[0]);
-      });
-    }));
+            expect(spy).toHaveBeenCalledWith(input1[0], input2[0]);
+          });
+        }));
   });
 });

--- a/src/operations/executors/graph_executor.ts
+++ b/src/operations/executors/graph_executor.ts
@@ -36,6 +36,7 @@ export let executeOp: OpExecutor = (node: Node, tensorMap: NamedTensorsMap,
           getParamValue('default', node, tensorMap, context) as tfc.Tensor;
       return [getTensor(node.name, tensorMap, context) || def];
     case 'identity':
+    case 'stopGradient':
       return [getParamValue('x', node, tensorMap, context) as tfc.Tensor];
     case 'shape':
       return [tfc.tensor1d(

--- a/src/operations/executors/graph_executor_test.ts
+++ b/src/operations/executors/graph_executor_test.ts
@@ -104,4 +104,12 @@ describe('graph', () => {
       expect(console.log).toHaveBeenCalledWith([1]);
     });
   });
+  describe('stopGradient', () => {
+    it('should return input', () => {
+      node.inputNames = ['input'];
+      node.params.x = createTensorAttr(0);
+      node.op = 'stopGradient';
+      expect(executeOp(node, {input: input1}, context)).toEqual(input1);
+    });
+  });
 });

--- a/src/operations/op_list/arithmetic.json
+++ b/src/operations/op_list/arithmetic.json
@@ -193,5 +193,22 @@
         "notSupported": true
       }
     ]
+  },
+  {
+    "tfOpName": "SquaredDifference",
+    "dlOpName": "squaredDifference",
+    "category": "arithmetic",
+    "params": [
+      {
+        "tfInputIndex": 0,
+        "dlParamName": "a",
+        "type": "tensor"
+      },
+      {
+        "tfInputIndex": 1,
+        "dlParamName": "b",
+        "type": "tensor"
+      }
+    ]
   }
 ]

--- a/src/operations/op_list/graph.json
+++ b/src/operations/op_list/graph.json
@@ -85,5 +85,17 @@
     "dlOpName": "noop",
     "category": "graph",
     "params": []
+  },
+  {
+    "tfOpName": "StopGradient",
+    "dlOpName": "stopGradient",
+    "category": "graph",
+    "params": [
+      {
+        "tfInputIndex": 0,
+        "dlParamName": "x",
+        "type": "tensor"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This adds [SquaredDifference](https://www.tensorflow.org/api_docs/python/tf/squared_difference) and [StopGradient](https://www.tensorflow.org/api_docs/python/tf/stop_gradient) ops support to converter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/94)
<!-- Reviewable:end -->
