### PR TITLE
Support tf.resizeNearestNeighbor

### DIFF
--- a/src/operations/executors/image_executor.ts
+++ b/src/operations/executors/image_executor.ts
@@ -38,6 +38,16 @@ export let executeOp: OpExecutor = (node: Node, tensorMap: NamedTensorsMap,
           images as tfc.Tensor3D | tfc.Tensor4D, [size[0], size[1]],
           alignCorners)];
     }
+    case 'resizeNearestNeighbor': {
+      const images =
+          getParamValue('images', node, tensorMap, context) as tfc.Tensor;
+      const size = getParamValue('size', node, tensorMap, context) as number[];
+      const alignCorners =
+          getParamValue('alignCorners', node, tensorMap, context) as boolean;
+      return [tfc.image.resizeNearestNeighbor(
+          images as tfc.Tensor3D | tfc.Tensor4D, [size[0], size[1]],
+          alignCorners)];
+    }
     default:
       throw TypeError(`Node type ${node.op} is not implemented`);
   }

--- a/src/operations/executors/image_executor_test.ts
+++ b/src/operations/executors/image_executor_test.ts
@@ -53,5 +53,17 @@ describe('image', () => {
             .toHaveBeenCalledWith(input1[0], [1, 2], true);
       });
     });
+    describe('resizeNearestNeighbor', () => {
+      it('should return input', () => {
+        node.op = 'resizeNearestNeighbor';
+        node.params['images'] = createTensorAttr(0);
+        node.params['size'] = createNumericArrayAttr([1, 2]);
+        node.params['alignCorners'] = createBoolAttr(true);
+        spyOn(tfc.image, 'resizeNearestNeighbor');
+        executeOp(node, {input1}, context);
+        expect(tfc.image.resizeNearestNeighbor)
+            .toHaveBeenCalledWith(input1[0], [1, 2], true);
+      });
+    });
   });
 });

--- a/src/operations/op_list/image.json
+++ b/src/operations/op_list/image.json
@@ -26,5 +26,33 @@
         "notSupported": true
       }
     ]
+  },
+  {
+    "tfOpName": "ResizeNearestNeighbor",
+    "dlOpName": "resizeNearestNeighbor",
+    "category": "image",
+    "params": [
+      {
+        "tfInputIndex": 0,
+        "dlParamName": "images",
+        "type": "tensor"
+      },
+      {
+        "tfInputIndex": 1,
+        "dlParamName": "size",
+        "type": "number[]"
+      },
+      {
+        "tfParamName": "align_corners",
+        "dlParamName": "alignCorners",
+        "type": "bool"
+      },
+      {
+        "tfParamName": "T",
+        "dlParamName": "dtype",
+        "type": "dtype",
+        "notSupported": true
+      }
+    ]
   }
 ]


### PR DESCRIPTION
TensorFlow.js core supports `resizeNearestNeighbor` from 0.9.0. 

see: https://github.com/tensorflow/tfjs-core/pull/955

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/101)
<!-- Reviewable:end -->
