### PR TITLE
replace Conv2dTranspose with Conv2dBackdropInput node

### DIFF
--- a/src/operations/op_list/convolution.json
+++ b/src/operations/op_list/convolution.json
@@ -172,7 +172,7 @@
     ]
   },
   {
-    "tfOpName": "Conv2DTranspose",
+    "tfOpName": "Conv2DBackpropInput",
     "dlOpName": "conv2dTranspose",
     "category": "convolution",
     "params": [
@@ -187,7 +187,7 @@
         "type": "tensor"
       },
       {
-        "tfParamName": "output_shape",
+        "tfInputIndex": 2,
         "dlParamName": "outputShape",
         "type": "number[]"
       },


### PR DESCRIPTION
TF actually only generates Conv2dBackdropInput, there is no Con2dTranspose node in the GraphDef.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/105)
<!-- Reviewable:end -->
