### PR TITLE
Fix a broken link in demo/mobilenet/README.md

### DIFF
--- a/demo/mobilenet/README.md
+++ b/demo/mobilenet/README.md
@@ -4,7 +4,7 @@ This demo imports the
 [MobileNet v1.0](https://github.com/tensorflow/models/blob/master/research/slim/nets/mobilenet_v1.md)
 model for inference in the browser. The model was pre-converted to TensorFlow.js
 format and hosted on Google Cloud, using the steps in
-the repo's [README.md](../README.md).
+the repo's [README.md](../../README.md).
 
 The following commands will start a web server on `localhost:1234` and open
 a browser page with the demo.

--- a/demo/mobilenet/mobilenet.js
+++ b/demo/mobilenet/mobilenet.js
@@ -56,9 +56,8 @@ export class MobileNet {
         PREPROCESS_DIVISOR);
     const reshapedInput =
         preprocessedInput.reshape([1, ...preprocessedInput.shape]);
-    const dict = {};
-    dict[INPUT_NODE_NAME] = reshapedInput;
-    return this.model.execute(dict, OUTPUT_NODE_NAME);
+    return this.model.execute(
+        {[INPUT_NODE_NAME]:reshapedInput}, OUTPUT_NODE_NAME);
   }
 
   getTopKClasses(predictions, topK) {


### PR DESCRIPTION
Just a quick fix for a broken link in demo/mobilenet/README.md
Plus, a small simplification in demo/mobilenet/mobilenet.js for readability by using computed property name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/109)
<!-- Reviewable:end -->
