### PR TITLE
Fixes and improvements to tensorflowjs_converter

### DIFF
--- a/python/tensorflowjs/converters/BUILD
+++ b/python/tensorflowjs/converters/BUILD
@@ -75,7 +75,9 @@ py_binary(
         ":keras_tfjs_loader",
         ":tf_saved_model_conversion",
         "//tensorflowjs:expect_h5py_installed",
+        "//tensorflowjs:expect_keras_installed",
         "//tensorflowjs:expect_tensorflow_installed",
+        "//tensorflowjs:version",
     ],
 )
 

--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -23,9 +23,11 @@ import json
 import os
 
 import h5py
+import keras
 import tensorflow as tf
 
 from tensorflowjs import quantization
+from tensorflowjs import version
 from tensorflowjs.converters import keras_h5_conversion
 from tensorflowjs.converters import keras_tfjs_loader
 from tensorflowjs.converters import tf_saved_model_conversion
@@ -120,15 +122,19 @@ def main():
   parser = argparse.ArgumentParser('TensorFlow.js model converters.')
   parser.add_argument(
       'input_path',
+      nargs='?',
       type=str,
       help='Path to the input file or directory. For input format "keras", '
       'an HDF5 (.h5) file is expected. For input format "tensorflow", '
       'a SavedModel directory, session bundle directory, frozen model file, '
       'or TF-Hub module is expected.')
   parser.add_argument(
+      'output_path', nargs='?', type=str, help='Path for all output artifacts.')
+  parser.add_argument(
       '--input_format',
       type=str,
-      required=True,
+      required=False,
+      default='tf_saved_model',
       choices=set(['keras', 'tf_saved_model', 'tf_session_bundle',
                    'tf_frozen_model', 'tf_hub', 'tensorflowjs']),
       help='Input format. '
@@ -160,16 +166,27 @@ def main():
       'format. Defaults to "serve". Applicable only if input format is '
       '"tf_saved_model".')
   parser.add_argument(
-      'output_path', type=str, help='Path for all output artifacts.')
-  parser.add_argument(
       '--quantization_bytes',
       type=int,
       choices=set(quantization.QUANTIZATION_BYTES_TO_DTYPES.keys()),
       help='How many bytes to optionally quantize/compress the weights to. 1- '
       'and 2-byte quantizaton is supported. The default (unquantized) size is '
       '4 bytes.')
+  parser.add_argument(
+      '--version',
+      '-v',
+      dest='show_version',
+      action='store_true',
+      help='Show versions of tensorflowjs and its dependencies')
 
   FLAGS = parser.parse_args()
+
+  if FLAGS.show_version:
+    print('\ntensorflowjs %s\n' % version.version)
+    print('Dependency versions:')
+    print('  keras %s' % keras.__version__)
+    print('  tensorflow %s' % tf.__version__)
+    return
 
   quantization_dtype = (
       quantization.QUANTIZATION_BYTES_TO_DTYPES[FLAGS.quantization_bytes]
@@ -212,7 +229,7 @@ def main():
   elif (FLAGS.input_format == 'tf_hub' and
         FLAGS.output_format == 'tensorflowjs'):
     tf_saved_model_conversion.convert_tf_hub_module(FLAGS.input_path,
-                                                    FLAGS.output_dir)
+                                                    FLAGS.output_path)
 
   elif (FLAGS.input_format == 'tensorflowjs' and
         FLAGS.output_format == 'keras'):

--- a/python/tensorflowjs/converters/keras_tfjs_loader.py
+++ b/python/tensorflowjs/converters/keras_tfjs_loader.py
@@ -106,7 +106,8 @@ def load_keras_model(config_json_path,
           for w in model.weights]
 
       if not weights_path_prefix:
-        weights_path_prefix = os.path.dirname(config_json_path)
+        weights_path_prefix = os.path.dirname(
+            os.path.realpath(config_json_path))
       if not os.path.isdir(weights_path_prefix):
         raise ValueError(
             'Weights path prefix is not an existing directory: %s' %

--- a/python/tensorflowjs/converters/keras_tfjs_loader_test.py
+++ b/python/tensorflowjs/converters/keras_tfjs_loader_test.py
@@ -76,6 +76,27 @@ class LoadKerasModelTest(tf.test.TestCase):
       # The two model JSONs should match exactly.
       self.assertEqual(model1.to_json(), model2.to_json())
 
+  def testLoadKerasModelWithCurrentWorkingDirectoryRelativePath(self):
+    with tf.Graph().as_default(), tf.Session():
+      tfjs_path = os.path.join(self._tmp_dir, 'model_for_test')
+      model1 = self._saveKerasModelForTest(tfjs_path)
+      model1_weight_values = model1.get_weights()
+
+    os.chdir(tfjs_path)
+    with tf.Graph().as_default(), tf.Session():
+      # Use a relative path under the current working directory.
+      model2 = keras_tfjs_loader.load_keras_model('model.json')
+
+      # Verify the equality of all the weight values.
+      model2_weight_values = model2.get_weights()
+      self.assertEqual(len(model1_weight_values), len(model2_weight_values))
+      for model1_weight_value, model2_weight_value in zip(
+          model1_weight_values, model2_weight_values):
+        self.assertAllClose(model1_weight_value, model2_weight_value)
+
+      # The two model JSONs should match exactly.
+      self.assertEqual(model1.to_json(), model2.to_json())
+
   def testLoadKerasModelWithoutWeights(self):
     """Test loading of model topology only, without loading weight values."""
     with tf.Graph().as_default(), tf.Session():
@@ -214,6 +235,7 @@ class LoadKerasModelTest(tf.test.TestCase):
         keras_tfjs_loader.load_keras_model(
             model_json_path,
             weights_data_buffers=[b'foo'], weights_path_prefix='bar')
+
 
 
 if __name__ == '__main__':

--- a/python/test_pip_package.py
+++ b/python/test_pip_package.py
@@ -214,15 +214,6 @@ class APIAndShellTest(tf.test.TestCase):
         glob.glob(os.path.join(output_dir, 'tensorflowjs_model.pb')))
     self.assertTrue(glob.glob(os.path.join(output_dir, 'group*-*')))
 
-  def testUsageWithoutInputFormatErrors(self):
-    process = subprocess.Popen(
-        ['tensorflowjs_converter', self._tmp_dir, self._tmp_dir],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE)
-    _, stderr = process.communicate()
-    self.assertGreater(process.returncode, 0)
-    self.assertIn(b'--input_format', tf.compat.as_bytes(stderr))
-
   def testInvalidInputFormatRaisesError(self):
     process = subprocess.Popen(
         [
@@ -379,6 +370,12 @@ class APIAndShellTest(tf.test.TestCase):
           os.path.join(self._tmp_dir, 'model.json'))
       model_2_json = model_2.to_json()
       self.assertEqual(model_json, model_2_json)
+
+  def testVersion(self):
+    process = subprocess.Popen(['tensorflowjs_converter', '--version'])
+    stdout, _ = process.communicate()
+    self.assertEqual(0, process.returncode)
+    self.assertIn('tensorflowjs %s' % tfjs.__version__, stdout)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes:
1. Make load_keras_model capable of handling relative path without
   a path.
2. Fix a typo with regard to TF Hub model conversion in converters.py:
   FLAGS.output_dir -->  FLAGS.output_path

Improvements:
1. Add syntax: tensorflowjs_converter --version