### PR TITLE
added StridedSlice op

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -202,6 +202,7 @@
 |Reverse|reverse|
 |ReverseV2|reverse|
 |Slice|slice|
+|StridedSlice|stridedSlice|
 |Split|split|
 |Tile|tile|
 

--- a/src/operations/op_list/slice_join.json
+++ b/src/operations/op_list/slice_join.json
@@ -166,13 +166,17 @@
       },
       {
         "tfInputIndex": 4,
+        "tfParamName": "begin_mask",
         "dlParamName": "beginMask",
-        "type": "number"
+        "type": "number",
+        "defaultValue": 0
       },
       {
         "tfInputIndex": 5,
+        "tfParamName": "end_mask",
         "dlParamName": "endMask",
-        "type": "number"
+        "type": "number",
+        "defaultValue": 0
       }
     ]
   },

--- a/src/operations/op_list/slice_join.json
+++ b/src/operations/op_list/slice_join.json
@@ -141,6 +141,42 @@
     ]
   },
   {
+    "tfOpName": "StridedSlice",
+    "dlOpName": "stridedSlice",
+    "category": "slice_join",
+    "params": [{
+        "tfInputIndex": 0,
+        "dlParamName": "x",
+        "type": "tensor"
+      },
+      {
+        "tfInputIndex": 1,
+        "dlParamName": "begin",
+        "type": "number[]"
+      },
+      {
+        "tfInputIndex": 2,
+        "dlParamName": "end",
+        "type": "number[]"
+      },
+      {
+        "tfInputIndex": 3,
+        "dlParamName": "strides",
+        "type": "number[]"
+      },
+      {
+        "tfInputIndex": 4,
+        "dlParamName": "beginMask",
+        "type": "number"
+      },
+      {
+        "tfInputIndex": 5,
+        "dlParamName": "endMask",
+        "type": "number"
+      }
+    ]
+  },
+  {
     "tfOpName": "Pack",
     "dlOpName": "stack",
     "category": "slice_join",

--- a/src/operations/op_list/slice_join.json
+++ b/src/operations/op_list/slice_join.json
@@ -165,14 +165,12 @@
         "type": "number[]"
       },
       {
-        "tfInputIndex": 4,
         "tfParamName": "begin_mask",
         "dlParamName": "beginMask",
         "type": "number",
         "defaultValue": 0
       },
       {
-        "tfInputIndex": 5,
         "tfParamName": "end_mask",
         "dlParamName": "endMask",
         "type": "number",


### PR DESCRIPTION
I checked this by using the Dockerfile mentioned in this PR https://github.com/tensorflow/tfjs/issues/305 but modified to replace `git clone --depth=1 https://github.com/tensorflow/tfjs-converter.git` with `git clone --depth=1 -b stridedSlice https://github.com/kylemcdonald/tfjs-converter.git`. Then I tried to convert a SavedModel that includes a StridedSlice operation:

```
$ docker run -it --mount type=bind,src="$(pwd)",dst=/root/mount tfjs bash
cd ~/mount && tensorflowjs_converter \
	--input_format=tf_saved_model \
	--output_node_names='resfcn256/Conv2d_transpose_16/Sigmoid' \
	saved_model \
	output
```

And it seems to work:

```
/opt/conda/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
  from ._conv import register_converters as _register_converters
Using TensorFlow backend.
WARNING:tensorflow:From /opt/conda/lib/python3.6/site-packages/tensorflow/contrib/learn/python/learn/datasets/base.py:198: retry (from tensorflow.contrib.learn.python.learn.datasets.base) is deprecated and will be removed in a future version.
Instructions for updating:
Use the retry module or similar alternatives.
2018-05-16 19:36:23.097294: I tensorflow/core/platform/cpu_feature_guard.cc:140] Your CPU supports instructions that this TensorFlow binary was not compiled to use: AVX2 FMA
Converted 245 variables to const ops.
2018-05-16 19:36:26.562328: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:221] Return status of optimizer model_pruner: OK. Graph size before: 973 nodes, 1033 edges. Graph size after: 728 nodes, 788 edges.
2018-05-16 19:36:26.562370: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:221] Return status of optimizer constant folding: OK. Graph size before: 728 nodes, 788 edges. Graph size after: 728 nodes, 788 edges.
2018-05-16 19:36:26.562379: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:221] Return status of optimizer arithmetic_optimizer: OK. Graph size before: 728 nodes, 788 edges. Graph size after: 537 nodes, 788 edges.
2018-05-16 19:36:26.562386: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:221] Return status of optimizer dependency_optimizer: OK. Graph size before: 537 nodes, 788 edges. Graph size after: 536 nodes, 764 edges.
2018-05-16 19:36:26.562393: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:221] Return status of optimizer model_pruner: OK. Graph size before: 536 nodes, 764 edges. Graph size after: 536 nodes, 764 edges.
2018-05-16 19:36:26.562400: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:221] Return status of optimizer constant folding: OK. Graph size before: 536 nodes, 764 edges. Graph size after: 536 nodes, 764 edges.
2018-05-16 19:36:26.562406: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:221] Return status of optimizer arithmetic_optimizer: OK. Graph size before: 536 nodes, 764 edges. Graph size after: 536 nodes, 764 edges.
2018-05-16 19:36:26.562413: I tensorflow/core/grappler/optimizers/meta_optimizer.cc:221] Return status of optimizer dependency_optimizer: OK. Graph size before: 536 nodes, 764 edges. Graph size after: 536 nodes, 764 edges.
Writing weight file output/tensorflowjs_model.pb...
```

But I still need to try getting it running in the browser next.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/131)
<!-- Reviewable:end -->
