### PR TITLE
Adds error handling for missing input_path

### DIFF
--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -193,6 +193,11 @@ def main():
     print('  tensorflow %s' % tf.__version__)
     return
 
+  if FLAGS.input_path is None:
+    raise ValueError(
+      'Error: The input_path argument must be set.  '
+      'Run with --help flag for usage information.')
+
   quantization_dtype = (
       quantization.QUANTIZATION_BYTES_TO_DTYPES[FLAGS.quantization_bytes]
       if FLAGS.quantization_bytes else None)

--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -195,8 +195,8 @@ def main():
 
   if FLAGS.input_path is None:
     raise ValueError(
-      'Error: The input_path argument must be set.  '
-      'Run with --help flag for usage information.')
+        'Error: The input_path argument must be set. '
+        'Run with --help flag for usage information.')
 
   quantization_dtype = (
       quantization.QUANTIZATION_BYTES_TO_DTYPES[FLAGS.quantization_bytes]

--- a/python/test_pip_package.py
+++ b/python/test_pip_package.py
@@ -248,6 +248,17 @@ class APIAndShellTest(tf.test.TestCase):
     self.assertGreater(process.returncode, 0)
     self.assertIn(b'--input_format', tf.compat.as_bytes(stderr))
 
+  def testMissingInputPathRaisesError(self):
+    process = subprocess.Popen(
+        [
+            'tensorflowjs_converter'
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+    _, stderr = process.communicate()
+    self.assertGreater(process.returncode, 0)
+    self.assertIn(b'input_path', tf.compat.as_bytes(stderr))
+
   def testKerasH5ConversionWorksFromCLI(self):
     # First create a toy keras model.
     os.makedirs(os.path.join(self._tmp_dir, 'keras_h5'))


### PR DESCRIPTION
Addresses the issue where a user runs with no arguments at all and gets an ugly error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/132)
<!-- Reviewable:end -->
