### PR TITLE
Fix issue in which saving of tf.keras.Models fails

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,5 +2,5 @@ h5py==2.7.1
 keras==2.1.4
 numpy==1.14.1
 six==1.11.0
-tensorflow==1.7.0
+tensorflow==1.8.0
 tensorflow_hub==0.1.0

--- a/python/tensorflowjs/converters/BUILD
+++ b/python/tensorflowjs/converters/BUILD
@@ -3,7 +3,6 @@ py_library(
     srcs = ["keras_h5_conversion.py"],
     deps = [
         "//tensorflowjs:expect_h5py_installed",
-        "//tensorflowjs:expect_keras_installed",
         "//tensorflowjs:expect_numpy_installed",
         "//tensorflowjs:write_weights",
     ],
@@ -18,6 +17,7 @@ py_test(
         "//tensorflowjs:expect_h5py_installed",
         "//tensorflowjs:expect_keras_installed",
         "//tensorflowjs:expect_numpy_installed",
+        "//tensorflowjs:expect_tensorflow_installed",
     ],
 )
 

--- a/python/tensorflowjs/converters/keras_h5_conversion.py
+++ b/python/tensorflowjs/converters/keras_h5_conversion.py
@@ -27,7 +27,6 @@ import os
 import tempfile
 
 import h5py
-import keras
 import numpy as np
 import six
 
@@ -261,7 +260,7 @@ def save_keras_model(model, artifacts_dir, quantization_dtype=None):
           fields:
           - 'modelTopology': A JSON object describing the topology of the model,
             along with additional information such as training. It is obtained
-            through calling `keras.models.save_model`.
+            through calling `model.save()`.
           - 'weightsManifest': A TensorFlow.js-format JSON manifest for the
             model's weights.
         - files containing weight values in groups, with the file name pattern
@@ -274,7 +273,7 @@ def save_keras_model(model, artifacts_dir, quantization_dtype=None):
     ValueError: If `artifacts_dir` already exists as a file (not a directory).
   """
   temp_h5_path = tempfile.mktemp() + '.h5'
-  keras.models.save_model(model, temp_h5_path)
+  model.save(temp_h5_path)
   # TODO(cais): Maybe get rid of the class HDF5Converter to simplify the code.
   converter = HDF5Converter()
   topology_json, weights_group = (

--- a/python/tensorflowjs/converters/keras_h5_conversion_test.py
+++ b/python/tensorflowjs/converters/keras_h5_conversion_test.py
@@ -27,6 +27,7 @@ import unittest
 import h5py
 import keras
 import numpy as np
+import tensorflow as tf
 
 from tensorflowjs.converters import keras_h5_conversion
 
@@ -194,6 +195,33 @@ class ConvertH5WeightsTest(unittest.TestCase):
     dense_layer = keras.layers.Dense(3)
     t_output = dense_layer(t_input)
     model = keras.Model(t_input, t_output)
+    keras_h5_conversion.save_keras_model(model, self._tmp_dir)
+
+    # Verify the content of the artifacts output directory.
+    self.assertTrue(
+        os.path.isfile(os.path.join(self._tmp_dir, 'group1-shard1of1')))
+    model_json = json.load(
+        open(os.path.join(self._tmp_dir, 'model.json'), 'rt'))
+
+    topology_json = model_json['modelTopology']
+    self.assertIn('keras_version', topology_json)
+    self.assertIn('backend', topology_json)
+    self.assertIn('model_config', topology_json)
+
+    weights_manifest = model_json['weightsManifest']
+    self.assertTrue(isinstance(weights_manifest, list))
+    self.assertEqual(1, len(weights_manifest))
+    self.assertIn('paths', weights_manifest[0])
+
+  def testSaveModelSucceedsForTfKerasNonSequentialModel(self):
+    t_input = tf.keras.Input([2])
+    dense_layer = tf.keras.layers.Dense(3)
+    t_output = dense_layer(t_input)
+    model = tf.keras.Model(t_input, t_output)
+
+    # `tf.keras.Model`s must be compiled before they can be saved.
+    model.compile(loss='mean_squared_error', optimizer='sgd')
+
     keras_h5_conversion.save_keras_model(model, self._tmp_dir)
 
     # Verify the content of the artifacts output directory.


### PR DESCRIPTION
BUG Fix issue in which saving of `tf.keras.Model`s using `tensorflowjs.converters.save_keras_model()` fails

Fixes: https://github.com/tensorflow/tfjs/issues/387

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/147)
<!-- Reviewable:end -->
