### PR TITLE
Relax peer dependency of tfjs-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "0.11.3"
+    "@tensorflow/tfjs-core": "~0.11.5"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "0.11.3",
+    "@tensorflow/tfjs-core": "~0.11.5",
     "@types/jasmine": "~2.8.6",
     "@types/node-fetch": "1.6.9",
     "ajv": "~6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,9 +45,9 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@tensorflow/tfjs-core@0.11.3":
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.11.3.tgz#2010306597a4b83afc999e6e2137946a97412632"
+"@tensorflow/tfjs-core@~0.11.5":
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.11.5.tgz#e8849f92a0def022d3b075dbc6133d94c60234f9"
   dependencies:
     seedrandom "~2.4.3"
 


### PR DESCRIPTION
The peer dependency for tfjs-core is pegged to a specific build version of tfjs-core, so when you install @tensorflow/tfjs, you often get an npm warning.

This will be followed by relaxing peer dep versions in `tfjs-converter` and `tfjs-node` as well.

See https://github.com/tensorflow/tfjs/issues/369 for the warning.
Related PR in tfjs-layers: https://github.com/tensorflow/tfjs-layers/pull/227

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/149)
<!-- Reviewable:end -->
