### PR TITLE
adds documentation for output .h5 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ $ tensorflowjs_converter \
 | Options | Description
 |---|---|
 |`--input_format`     | The format of input model, use tf_saved_model for SavedModel, tf_frozen_model for frozen model, tf_session_bundle for session bundle, tf_hub for TensorFlow Hub module and keras for Keras HDF5. |
-|`--output_node_names`| The names of the output nodes, separated by commas.|
-|`--saved_model_tags` | Only applicable to SavedModel conversion, Tags of the MetaGraphDef to load, in comma separated format. Defaults to `serve`.|
+|<nobr>`--output_node_names`</nobr>| The names of the output nodes, separated by commas.|
+|`--output_format`| The desired output format.  Must be `tensorflowjs` (the default) or `keras`.  |
+|<nobr>`--saved_model_tags`</nobr> | Only applicable to SavedModel conversion, Tags of the MetaGraphDef to load, in comma separated format. Defaults to `serve`.|
 |`--signature_name`   | Only applicable to TensorFlow Hub module conversion, signature to load. Defaults to `default`. See https://www.tensorflow.org/hub/common_signatures/.|
 
 

--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ $ tensorflowjs_converter \
 
 | input format | output `tensorflowjs` | output `keras` |
 |---|---|---|
-|`tensorflowjs`| :x: | :heavy_check_mark: |
-|`tf_saved_model`| :heavy_check_mark: | :x: |
-|`tf_frozen_model`| :heavy_check_mark: | :x: |
-|`tf_session_bundle`| :heavy_check_mark: | :x: |
-|`tf_hub`| :heavy_check_mark: | :x: |
 |`keras`| :heavy_check_mark: | :x: |
+|`tensorflowjs`| :x: | :heavy_check_mark: |
+|`tf_frozen_model`| :heavy_check_mark: | :x: |
+|`tf_hub`| :heavy_check_mark: | :x: |
+|`tf_saved_model`| :heavy_check_mark: | :x: |
+|`tf_session_bundle`| :heavy_check_mark: | :x: |
 
 ### Web-friendly format
 

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ $ tensorflowjs_converter \
 |---|---|
 |`--input_format`     | The format of input model, use tf_saved_model for SavedModel, tf_frozen_model for frozen model, tf_session_bundle for session bundle, tf_hub for TensorFlow Hub module and keras for Keras HDF5. |
 |<nobr>`--output_node_names`</nobr>| The names of the output nodes, separated by commas.|
-|`--output_format`| The desired output format.  Must be `tensorflowjs` (the default) or `keras`.  |
-|<nobr>`--saved_model_tags`</nobr> | Only applicable to SavedModel conversion, Tags of the MetaGraphDef to load, in comma separated format. Defaults to `serve`.|
+|`--output_format`| The desired output format.  Must be `tensorflowjs` (the default) or `keras`.  Not all pairs of input-output formats are supported.  Please file a [github issue](https://github.com/tensorflow/tfjs/issues) if your desired input-output pair is not supported.|
+|<nobr>`--saved_model_tags`</nobr> | Only applicable to SavedModel conversion. Tags of the MetaGraphDef to load, in comma separated format. Defaults to `serve`.|
 |`--signature_name`   | Only applicable to TensorFlow Hub module conversion, signature to load. Defaults to `default`. See https://www.tensorflow.org/hub/common_signatures/.|
 
 

--- a/README.md
+++ b/README.md
@@ -84,12 +84,23 @@ $ tensorflowjs_converter \
 
 | Options | Description
 |---|---|
-|`--input_format`     | The format of input model, use tf_saved_model for SavedModel, tf_frozen_model for frozen model, tf_session_bundle for session bundle, tf_hub for TensorFlow Hub module and keras for Keras HDF5. |
+|`--input_format`     | The format of input model, use `tf_saved_model` for SavedModel, `tf_frozen_model` for frozen model, `tf_session_bundle` for session bundle, `tf_hub` for TensorFlow Hub module, `tensorflowjs` for TensorFlow.js JSON format, and `keras` for Keras HDF5. |
 |<nobr>`--output_node_names`</nobr>| The names of the output nodes, separated by commas.|
 |`--output_format`| The desired output format.  Must be `tensorflowjs` (the default) or `keras`.  Not all pairs of input-output formats are supported.  Please file a [github issue](https://github.com/tensorflow/tfjs/issues) if your desired input-output pair is not supported.|
 |<nobr>`--saved_model_tags`</nobr> | Only applicable to SavedModel conversion. Tags of the MetaGraphDef to load, in comma separated format. Defaults to `serve`.|
 |`--signature_name`   | Only applicable to TensorFlow Hub module conversion, signature to load. Defaults to `default`. See https://www.tensorflow.org/hub/common_signatures/.|
 
+
+### Format conversions support table
+
+| input format | output `tensorflowjs` | output `keras` |
+|---|---|---|
+|`tensorflowjs`| :x: | :heavy_check_mark: |
+|`tf_saved_model`| :heavy_check_mark: | :x: |
+|`tf_frozen_model`| :heavy_check_mark: | :x: |
+|`tf_session_bundle`| :heavy_check_mark: | :x: |
+|`tf_hub`| :heavy_check_mark: | :x: |
+|`keras`| :heavy_check_mark: | :x: |
 
 ### Web-friendly format
 


### PR DESCRIPTION
(documentation)  Adds documentation for output option.  Fixes a line breaking issue with flag names being broken into two lines on narrow screens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/153)
<!-- Reviewable:end -->
