### PR TITLE
Reduction Ops: Adds all and any support to converter

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -194,6 +194,8 @@
 |Mean|mean|
 |Min|min|
 |Sum|sum|
+|All||all|
+|Any||any|
 |Not mapped|logSumExp|
 |Not mapped|unsortedSegmentSum|
 

--- a/src/operations/executors/reduction_executor.ts
+++ b/src/operations/executors/reduction_executor.ts
@@ -60,6 +60,22 @@ export let executeOp: OpExecutor = (node: Node, tensorMap: NamedTensorsMap,
           getParamValue('x', node, tensorMap, context) as tfc.Tensor, axis,
           keepDims)];
     }
+    case 'all': {
+      const axis = getParamValue('axis', node, tensorMap, context) as number[];
+      const keepDims =
+          getParamValue('keepDims', node, tensorMap, context) as boolean;
+      return [tfc.all(
+          getParamValue('x', node, tensorMap, context) as tfc.Tensor, axis,
+          keepDims)];
+    }
+    case 'any': {
+      const axis = getParamValue('axis', node, tensorMap, context) as number[];
+      const keepDims =
+          getParamValue('keepDims', node, tensorMap, context) as boolean;
+      return [tfc.any(
+          getParamValue('x', node, tensorMap, context) as tfc.Tensor, axis,
+          keepDims)];
+    }
     case 'argMax': {
       const axis = getParamValue('axis', node, tensorMap, context) as number;
       return [tfc.argMax(

--- a/src/operations/executors/reduction_executor_test.ts
+++ b/src/operations/executors/reduction_executor_test.ts
@@ -45,7 +45,7 @@ describe('reduction', () => {
   });
 
   describe('executeOp', () => {
-    ['max', 'mean', 'min', 'sum'].forEach(op => {
+    ['max', 'mean', 'min', 'sum', 'all', 'any'].forEach(op => {
       it('should call tfc.' + op, () => {
         const spy = spyOn(tfc, op as 'max');
         node.op = op;

--- a/src/operations/op_list/reduction.json
+++ b/src/operations/op_list/reduction.json
@@ -88,6 +88,50 @@
     ]
   },
   {
+    "tfOpName": "All",
+    "dlOpName": "all",
+    "category": "reduction",
+    "params": [
+      {
+        "tfInputIndex": 0,
+        "dlParamName": "x",
+        "type": "tensor"
+      },
+      {
+        "tfInputIndex": 1,
+        "dlParamName": "axis",
+        "type": "number[]"
+      },
+      {
+        "tfParamName": "keep_dims",
+        "dlParamName": "keepDims",
+        "type": "bool"
+      }
+    ]
+  },
+  {
+    "tfOpName": "Any",
+    "dlOpName": "any",
+    "category": "reduction",
+    "params": [
+      {
+        "tfInputIndex": 0,
+        "dlParamName": "x",
+        "type": "tensor"
+      },
+      {
+        "tfInputIndex": 1,
+        "dlParamName": "axis",
+        "type": "number[]"
+      },
+      {
+        "tfParamName": "keep_dims",
+        "dlParamName": "keepDims",
+        "type": "bool"
+      }
+    ]
+  },
+  {
     "tfOpName": "ArgMax",
     "dlOpName": "argMax",
     "category": "reduction",


### PR DESCRIPTION
This PR adds support for `tf.all` and `tf.any` to the converter.
