### PR TITLE
Remove dependency on tfjs-core/dist.

### DIFF
--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -14,8 +14,18 @@
  * limitations under the License.
  * =============================================================================
  */
-import {Tensor} from '@tensorflow/tfjs-core';
+import {DataType, Tensor} from '@tensorflow/tfjs-core';
+
+export type NamedTensorMap = {
+  [key: string]: Tensor
+};
 
 export type NamedTensorsMap = {
   [key: string]: Tensor[]
 };
+
+export interface TensorInfo {
+  name: string;
+  shape?: number[];
+  dtype: DataType;
+}

--- a/src/executor/frozen_model.ts
+++ b/src/executor/frozen_model.ts
@@ -16,11 +16,10 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
-import {TensorInfo} from '@tensorflow/tfjs-core/dist/types';
 import * as Url from 'url';
 
 import {tensorflow} from '../data/compiled_api';
-import {NamedTensorsMap} from '../data/types';
+import {NamedTensorsMap, TensorInfo} from '../data/types';
 import {OperationMapper} from '../operations/operation_mapper';
 
 import {GraphExecutor} from './graph_executor';

--- a/src/executor/graph_executor.ts
+++ b/src/executor/graph_executor.ts
@@ -15,10 +15,10 @@
  * =============================================================================
  */
 
-import {NamedTensorMap, Tensor, tidy, util} from '@tensorflow/tfjs-core';
-import {DataType, TensorInfo} from '@tensorflow/tfjs-core/dist/types';
+// tslint:disable-next-line:max-line-length
+import {DataType, Tensor, tidy, util} from '@tensorflow/tfjs-core';
 
-import {NamedTensorsMap} from '../data/types';
+import {NamedTensorMap, NamedTensorsMap, TensorInfo} from '../data/types';
 import {getNodeNameAndIndex, getTensor} from '../operations/executors/utils';
 import {executeOp} from '../operations/operation_executor';
 import {Graph, Node} from '../operations/types';

--- a/src/executor/tensor_array.ts
+++ b/src/executor/tensor_array.ts
@@ -15,10 +15,7 @@
  * =============================================================================
  */
 // tslint:disable-next-line:max-line-length
-import {concat, slice, stack, Tensor, tensor, unstack} from '@tensorflow/tfjs-core';
-import {tidy} from '@tensorflow/tfjs-core';
-import {DataType} from '@tensorflow/tfjs-core/dist/types';
-import {assertShapesMatch} from '@tensorflow/tfjs-core/dist/util';
+import {concat, DataType, slice, stack, Tensor, tensor, tidy, unstack, util} from '@tensorflow/tfjs-core';
 
 export interface TensorWithState {
   tensor?: Tensor;
@@ -117,7 +114,7 @@ export class TensorArray {
           because the value dtype is ${
           tensor.dtype}, but TensorArray dtype is ${this.dtype}.`);
     }
-    assertShapesMatch(
+    util.assertShapesMatch(
         this.elementShape, tensor.shape,
         `TensorArray ${this.name}: Could not write to TensorArray index ${
             index}.`);
@@ -184,7 +181,7 @@ export class TensorArray {
     // their memory.
     const tensors = this.readMany(indices);
 
-    assertShapesMatch(
+    util.assertShapesMatch(
         this.elementShape, tensors[0].shape, 'TensorArray shape mismatch: ');
 
     return stack(tensors, 0);
@@ -210,7 +207,7 @@ export class TensorArray {
     // Collect all the tensors from the tensors array.
     const tensors = this.readMany(indices);
 
-    assertShapesMatch(
+    util.assertShapesMatch(
         this.elementShape, tensors[0].shape,
         `TensorArray shape mismatch: tensor array shape (${
             this.elementShape}) vs first tensor shape (${tensors[0].shape})`);

--- a/src/operations/executors/creation_executor.ts
+++ b/src/operations/executors/creation_executor.ts
@@ -16,7 +16,6 @@
  */
 
 import * as tfc from '@tensorflow/tfjs-core';
-import {DataType} from '@tensorflow/tfjs-core/dist/types';
 
 import {NamedTensorsMap} from '../../data/types';
 import {ExecutionContext} from '../../executor/execution_context';
@@ -54,7 +53,7 @@ export let executeOp: OpExecutor = (node: Node, tensorMap: NamedTensorsMap,
     case 'ones': {
       return [tfc.ones(
           getParamValue('shape', node, tensorMap, context) as number[],
-          getParamValue('dtype', node, tensorMap, context) as DataType)];
+          getParamValue('dtype', node, tensorMap, context) as tfc.DataType)];
     }
     case 'onesLike': {
       return [tfc.onesLike(
@@ -66,7 +65,7 @@ export let executeOp: OpExecutor = (node: Node, tensorMap: NamedTensorsMap,
           getParamValue('shape', node, tensorMap, context) as any,
           getParamValue('minval', node, tensorMap, context) as number,
           getParamValue('maxval', node, tensorMap, context) as number,
-          getParamValue('dtype', node, tensorMap, context) as DataType)];
+          getParamValue('dtype', node, tensorMap, context) as tfc.DataType)];
     }
     case 'range': {
       const start = getParamValue('start', node, tensorMap, context) as number;
@@ -93,7 +92,7 @@ export let executeOp: OpExecutor = (node: Node, tensorMap: NamedTensorsMap,
     case 'zeros': {
       return [tfc.zeros(
           getParamValue('shape', node, tensorMap, context) as number[],
-          getParamValue('dtype', node, tensorMap, context) as DataType)];
+          getParamValue('dtype', node, tensorMap, context) as tfc.DataType)];
     }
     case 'zerosLike': {
       return [tfc.zerosLike(

--- a/src/operations/operation_mapper.ts
+++ b/src/operations/operation_mapper.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  * =============================================================================
  */
-import {DataType} from '@tensorflow/tfjs-core/dist/types';
+import {DataType} from '@tensorflow/tfjs-core';
+
 import {tensorflow} from '../data/compiled_api';
 
 import {getNodeNameAndIndex} from './executors/utils';
-
 import * as arithmetic from './op_list/arithmetic.json';
 import * as basicMath from './op_list/basic_math.json';
 import * as control from './op_list/control.json';


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs/issues/484

We should never import from `dist/`. If we need something in `dist/` it should be exported as part of the public API.

I opted for duplicating types that will never change instead of exporting from core and importing. It's better to have fewer symbols and decouple the two libraries for simple types.

cc @pyu10055 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/166)
<!-- Reviewable:end -->
