### PR TITLE
Add `--strip_debug_ops` flag to remove prints, asserts, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ tensorflowjs_converter \
 |`--output_format`| The desired output format.  Must be `tensorflowjs` (the default) or `keras`.  Not all pairs of input-output formats are supported.  Please file a [github issue](https://github.com/tensorflow/tfjs/issues) if your desired input-output pair is not supported.|
 |<nobr>`--saved_model_tags`</nobr> | Only applicable to SavedModel conversion. Tags of the MetaGraphDef to load, in comma separated format. Defaults to `serve`.|
 |`--signature_name`   | Only applicable to TensorFlow Hub module conversion, signature to load. Defaults to `default`. See https://www.tensorflow.org/hub/common_signatures/.|
-|`--strip_debug_ops`   | Strips out TensorFlow debug operations `tf.Print`, `tf.Assert`, `tf.check_numerics`. Defaults to `True`.|
+|`--strip_debug_ops`   | Strips out TensorFlow debug operations `Print`, `Assert`, `CheckNumerics`. Defaults to `True`.|
 
 
 ### Format conversions support table

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ $ tensorflowjs_converter \
 |`--output_format`| The desired output format.  Must be `tensorflowjs` (the default) or `keras`.  Not all pairs of input-output formats are supported.  Please file a [github issue](https://github.com/tensorflow/tfjs/issues) if your desired input-output pair is not supported.|
 |<nobr>`--saved_model_tags`</nobr> | Only applicable to SavedModel conversion. Tags of the MetaGraphDef to load, in comma separated format. Defaults to `serve`.|
 |`--signature_name`   | Only applicable to TensorFlow Hub module conversion, signature to load. Defaults to `default`. See https://www.tensorflow.org/hub/common_signatures/.|
+|`--strip_debug_ops`   | Strips out TensorFlow debug operations `tf.Print`, `tf.Assert`, `tf.check_numerics`. Defaults to `True`.|
 
 
 ### Format conversions support table

--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -191,7 +191,7 @@ def main():
   parser.add_argument(
       '--strip_debug_ops',
       type=bool,
-      default=False,
+      default=True,
       help='Strip debug ops (Assert, CheckNumerics, Print) from graph.')
 
   FLAGS = parser.parse_args()

--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -192,7 +192,7 @@ def main():
       '--strip_debug_ops',
       type=bool,
       default=True,
-      help='Strip debug ops (Assert, CheckNumerics, Print) from graph.')
+      help='Strip debug ops (Print, Assert, CheckNumerics) from graph.')
 
   FLAGS = parser.parse_args()
 

--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -188,6 +188,11 @@ def main():
       type=bool,
       default=False,
       help='Skip op validation for TensorFlow model conversion.')
+  parser.add_argument(
+      '--strip_debug_ops',
+      type=bool,
+      default=False,
+      help='Strip debug ops (Assert, CheckNumerics, Print) from graph.')
 
   FLAGS = parser.parse_args()
 
@@ -233,33 +238,38 @@ def main():
         FLAGS.input_path, FLAGS.output_node_names,
         FLAGS.output_path, saved_model_tags=FLAGS.saved_model_tags,
         quantization_dtype=quantization_dtype,
-        skip_op_check=FLAGS.skip_op_check)
+        skip_op_check=FLAGS.skip_op_check,
+        strip_debug_ops=FLAGS.strip_debug_ops)
 
   elif (FLAGS.input_format == 'tf_session_bundle' and
         FLAGS.output_format == 'tensorflowjs'):
     tf_saved_model_conversion.convert_tf_session_bundle(
         FLAGS.input_path, FLAGS.output_node_names,
         FLAGS.output_path, quantization_dtype=quantization_dtype,
-        skip_op_check=FLAGS.skip_op_check)
+        skip_op_check=FLAGS.skip_op_check,
+        strip_debug_ops=FLAGS.strip_debug_ops)
 
   elif (FLAGS.input_format == 'tf_frozen_model' and
         FLAGS.output_format == 'tensorflowjs'):
     tf_saved_model_conversion.convert_tf_frozen_model(
         FLAGS.input_path, FLAGS.output_node_names,
         FLAGS.output_path, quantization_dtype=quantization_dtype,
-        skip_op_check=FLAGS.skip_op_check)
+        skip_op_check=FLAGS.skip_op_check,
+        strip_debug_ops=FLAGS.strip_debug_ops)
 
   elif (FLAGS.input_format == 'tf_hub' and
         FLAGS.output_format == 'tensorflowjs'):
     if FLAGS.signature_name:
       tf_saved_model_conversion.convert_tf_hub_module(
           FLAGS.input_path, FLAGS.output_path, FLAGS.signature_name,
-          skip_op_check=FLAGS.skip_op_check)
+          skip_op_check=FLAGS.skip_op_check,
+          strip_debug_ops=FLAGS.strip_debug_ops)
     else:
       tf_saved_model_conversion.convert_tf_hub_module(
           FLAGS.input_path,
           FLAGS.output_path,
-          skip_op_check=FLAGS.skip_op_check)
+          skip_op_check=FLAGS.skip_op_check,
+          strip_debug_ops=FLAGS.strip_debug_ops)
 
   elif (FLAGS.input_format == 'tensorflowjs' and
         FLAGS.output_format == 'keras'):


### PR DESCRIPTION
Adds a flag to `tensorflowjs_converter` which removes debug operations from the Graph before saving in tf.js format.

Specifically, this adds a [`debug_stripper`](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/grappler/optimizers/debug_stripper.cc) to the Grappler optimization procedure to remove `Print`, `Assert`, and `CheckNumerics` operations.

Fixes [this issue](https://github.com/tensorflow/tfjs/issues/55)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/175)
<!-- Reviewable:end -->
