### PR TITLE
Fix wrong assumption about the order of weights in a keras Model

### DIFF
--- a/python/tensorflowjs/converters/keras_tfjs_loader_test.py
+++ b/python/tensorflowjs/converters/keras_tfjs_loader_test.py
@@ -386,6 +386,63 @@ class LoadKerasModelTest(tf.test.TestCase):
             model_json_path,
             weights_data_buffers=[b'foo'], weights_path_prefix='bar')
 
+  def testLoadFunctionalKerasModel(self):
+    with tf.Graph().as_default(), tf.Session():
+      input1 = keras.Input([4])
+      x1 = keras.layers.Dense(2, activation='relu')(input1)
+      x1 = keras.layers.BatchNormalization()(x1)
+
+      input2 = keras.Input([10])
+      x2 = keras.layers.Dense(5, activation='relu')(input2)
+      x2 = keras.layers.BatchNormalization()(x2)
+
+      y = keras.layers.Concatenate()([x1, x2])
+      y = keras.layers.Dense(1, activation='sigmoid')(y)
+
+      model = keras.Model([input1, input2], y)
+      model.compile(loss='binary_crossentropy', optimizer='sgd')
+
+      input1_val = np.ones([1, 4])
+      input2_val = np.ones([1, 10])
+      predict_out = model.predict([input1_val, input2_val])
+
+      save_dir = os.path.join(self._tmp_dir, 'functional_model')
+      keras_h5_conversion.save_keras_model(model, save_dir)
+
+    with tf.Graph().as_default(), tf.Session():
+      model2 = keras_tfjs_loader.load_keras_model(
+          os.path.join(save_dir, 'model.json'))
+      self.assertAllClose(
+          predict_out, model2.predict([input1_val, input2_val]))
+
+  def testLoadFunctionalTfKerasModel(self):
+    with tf.Graph().as_default(), tf.Session():
+      input1 = tf.keras.Input([4])
+      x1 = tf.keras.layers.Dense(2, activation='relu')(input1)
+      x1 = tf.keras.layers.BatchNormalization()(x1)
+
+      input2 = tf.keras.Input([10])
+      x2 = tf.keras.layers.Dense(5, activation='relu')(input2)
+      x2 = tf.keras.layers.BatchNormalization()(x2)
+
+      y = tf.keras.layers.Concatenate()([x1, x2])
+      y = tf.keras.layers.Dense(1, activation='sigmoid')(y)
+
+      model = tf.keras.Model([input1, input2], y)
+      model.compile(loss='binary_crossentropy', optimizer='sgd')
+
+      input1_val = np.ones([1, 4])
+      input2_val = np.ones([1, 10])
+      predict_out = model.predict([input1_val, input2_val])
+
+      save_dir = os.path.join(self._tmp_dir, 'functional_model')
+      keras_h5_conversion.save_keras_model(model, save_dir)
+
+    with tf.Graph().as_default(), tf.Session():
+      model2 = keras_tfjs_loader.load_keras_model(
+          os.path.join(save_dir, 'model.json'))
+      self.assertAllClose(
+          predict_out, model2.predict([input1_val, input2_val]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously a wrong assumption was made about the ordering of
weight values required for the input argument to
`keras.Model.set_weights()` and `tf.keras.Model.set_weights()`.

It turns out that the correct ordering is obtained by
- iterating over Model.layers, and
- in an inner loop, iterate over the weights of the indivisual Layers

Previously the ordering was iterating over Model.weights, which
can differ from the above-mentioned ordering in some cases, e.g.,
in a functional model with BatchNormalization Layers as covered
by the unit tests added in this PR.

BUG

Fixes: https://github.com/tensorflow/tfjs/issues/511

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/178)
<!-- Reviewable:end -->
