### PR TITLE
Fix bug with param value inference

### DIFF
--- a/src/operations/operation_mapper.ts
+++ b/src/operations/operation_mapper.ts
@@ -215,8 +215,8 @@ export class OperationMapper {
   private getNumberParam(
       attrs: {[key: string]: tensorflow.IAttrValue}, name: string,
       def: number): number {
-    const param = attrs[name];
-    const value = (param ? ((param.f !== undefined) ? param.f : param.i) : def);
+    const param = attrs[name] as tensorflow.AttrValue;
+    const value = (param ? ((param.value === "f") ? param.f : param.i) : def);
     return (typeof value === 'number') ? value : value['toInt']();
   }
   private getDtypeParam(

--- a/src/operations/operation_mapper_test.ts
+++ b/src/operations/operation_mapper_test.ts
@@ -35,7 +35,7 @@ const SIMPLE_MODEL: tensorflow.IGraphDef = {
         shape: {shape: {dim: [{size: 3}, {size: 3}, {size: 3}, {size: 1}]}}
       }
     },
-    {
+   {
       name: 'Const',
       op: 'Const',
       attr: {
@@ -48,7 +48,7 @@ const SIMPLE_MODEL: tensorflow.IGraphDef = {
           }
         }
       }
-    },
+    }, 
     {
       name: 'Shape',
       op: 'Const',
@@ -94,6 +94,14 @@ const SIMPLE_MODEL: tensorflow.IGraphDef = {
       op: 'Squeeze',
       input: ['BiasAdd'],
       attr: {squeeze_dims: {list: {i: [Long.fromInt(1), Long.fromInt(2)]}}}
+    },
+    {
+      name: 'Split',
+      op: 'Split',
+      input: ['image_placeholder'],
+      attr: {
+        num_split: {i: 3}
+      }
     }
   ],
   versions: {producer: 1.0}
@@ -115,14 +123,14 @@ describe('operationMapper', () => {
 
       it('should find the graph output nodes', () => {
         expect(graph.outputs.map(node => node.name)).toEqual([
-          'Fill', 'Squeeze'
+          'Fill', 'Squeeze', 'Split'
         ]);
       });
 
       it('should convert nodes', () => {
         expect(Object.keys(graph.nodes)).toEqual([
           'image_placeholder', 'Const', 'Shape', 'Value', 'Fill', 'Conv2D',
-          'BiasAdd', 'Squeeze'
+          'BiasAdd', 'Squeeze', 'Split'
         ]);
       });
     });
@@ -135,7 +143,7 @@ describe('operationMapper', () => {
       });
       it('should find the children nodes', () => {
         expect(graph.nodes['image_placeholder'].children.map(node => node.name))
-            .toEqual(['Conv2D']);
+            .toEqual(['Conv2D', 'Split']);
       });
 
       it('should map the input params', () => {
@@ -150,6 +158,7 @@ describe('operationMapper', () => {
         expect(graph.nodes['Conv2D'].params['pad'].value).toEqual('valid');
         expect(graph.nodes['Conv2D'].params['useCudnnOnGpu'].value)
             .toEqual(true);
+        expect(graph.nodes['Split'].params['numOrSizeSplits'].value).toEqual(3);
       });
 
       it('should map the placeholder attribute params', () => {


### PR DESCRIPTION
There was a bug with operations that use integer parameters such as `Split`. These were being given a default float value of `0`, so `param.f` was never evaluating to `undefined`. Accordingly, the result for all integer parameters was always `0`.

Fixes [535](https://github.com/tensorflow/tfjs/issues/535)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/180)
<!-- Reviewable:end -->
