### PR TITLE
Support writing weights of type bool

### DIFF
--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -21,7 +21,7 @@ import os
 import numpy as np
 from tensorflowjs import quantization
 
-_OUTPUT_DTYPES = [np.float32, np.int32, np.uint8, np.uint16]
+_OUTPUT_DTYPES = [np.float32, np.int32, np.uint8, np.uint16, np.bool]
 
 def write_weights(
     weight_groups, write_dir, shard_size_bytes=1024 * 1024 * 4,

--- a/python/tensorflowjs/write_weights_test.py
+++ b/python/tensorflowjs/write_weights_test.py
@@ -66,6 +66,37 @@ class TestWriteWeights(unittest.TestCase):
     weight1 = np.fromfile(weights_path, 'float32')
     np.testing.assert_array_equal(weight1, np.array([1, 2, 3], 'float32'))
 
+  def test_1_group_1_weight_bool(self):
+    groups = [
+        [{
+            'name': 'weight1',
+            'data': np.array([True, False, True], 'bool')
+        }]
+    ]
+
+    manifest_json = write_weights.write_weights(
+        groups, TMP_DIR, shard_size_bytes=4 * 4)
+    manifest = json.loads(manifest_json)
+
+    self.assertTrue(
+        os.path.isfile(os.path.join(TMP_DIR, 'weights_manifest.json')),
+        'weights_manifest.json does not exist')
+
+    self.assertEqual(
+        manifest,
+        [{
+            'paths': ['group1-shard1of1'],
+            'weights': [{
+                'name': 'weight1',
+                'shape': [3],
+                'dtype': 'bool'
+            }]
+        }])
+
+    weights_path = os.path.join(TMP_DIR, 'group1-shard1of1')
+    weight1 = np.fromfile(weights_path, 'bool')
+    np.testing.assert_array_equal(weight1, np.array([True, False, True], 'bool'))
+
   def test_1_group_1_weight_sharded(self):
     groups = [
         [{

--- a/python/tensorflowjs/write_weights_test.py
+++ b/python/tensorflowjs/write_weights_test.py
@@ -178,6 +178,9 @@ class TestWriteWeights(unittest.TestCase):
             'data': np.array([1, 2, 3], 'int32')
         }, {
             'name': 'weight2',
+            'data': np.array([True, False, False, True], 'bool')
+        }, {
+            'name': 'weight3',
             'data': np.array([4.1, 5.1], 'float32')
         }]
     ]
@@ -204,6 +207,10 @@ class TestWriteWeights(unittest.TestCase):
                 'dtype': 'int32'
             }, {
                 'name': 'weight2',
+                'shape': [4],
+                'dtype': 'bool'
+            }, {
+                'name': 'weight3',
                 'shape': [2],
                 'dtype': 'float32'
             }]
@@ -219,12 +226,12 @@ class TestWriteWeights(unittest.TestCase):
       shard_2_bytes = f.read()
     shard_2_int = np.frombuffer(shard_2_bytes[:4], 'int32')
     np.testing.assert_array_equal(shard_2_int, np.array([3], 'int32'))
-    shard_2_float = np.frombuffer(shard_2_bytes[4:], 'float32')
-    np.testing.assert_array_equal(shard_2_float, np.array([4.1], 'float32'))
+    shard_2_bool = np.frombuffer(shard_2_bytes[4:], 'bool')
+    np.testing.assert_array_equal(shard_2_bool, np.array([True, False, False, True], 'bool'))
 
     shard_3_path = os.path.join(TMP_DIR, 'group1-shard3of3')
     shard_3 = np.fromfile(shard_3_path, 'float32')
-    np.testing.assert_array_equal(shard_3, np.array([5.1], 'float32'))
+    np.testing.assert_array_equal(shard_3, np.array([4.1, 5.1], 'float32'))
 
   def test_2_groups_4_weights_sharded_packed(self):
     groups = [

--- a/python/tensorflowjs/write_weights_test.py
+++ b/python/tensorflowjs/write_weights_test.py
@@ -95,7 +95,8 @@ class TestWriteWeights(unittest.TestCase):
 
     weights_path = os.path.join(TMP_DIR, 'group1-shard1of1')
     weight1 = np.fromfile(weights_path, 'bool')
-    np.testing.assert_array_equal(weight1, np.array([True, False, True], 'bool'))
+    np.testing.assert_array_equal(
+        weight1, np.array([True, False, True], 'bool'))
 
   def test_1_group_1_weight_sharded(self):
     groups = [
@@ -227,7 +228,8 @@ class TestWriteWeights(unittest.TestCase):
     shard_2_int = np.frombuffer(shard_2_bytes[:4], 'int32')
     np.testing.assert_array_equal(shard_2_int, np.array([3], 'int32'))
     shard_2_bool = np.frombuffer(shard_2_bytes[4:], 'bool')
-    np.testing.assert_array_equal(shard_2_bool, np.array([True, False, False, True], 'bool'))
+    np.testing.assert_array_equal(
+        shard_2_bool, np.array([True, False, False, True], 'bool'))
 
     shard_3_path = os.path.join(TMP_DIR, 'group1-shard3of3')
     shard_3 = np.fromfile(shard_3_path, 'float32')


### PR DESCRIPTION
This makes the converter able to dump weights of dtype `bool`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/186)
<!-- Reviewable:end -->
