### PR TITLE
Publish source maps to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -16,7 +16,6 @@ npm-debug.log
 *.tgz
 *.txt
 karma.conf.js
-dist/**/*.js.map
 dist/**/*_test.js
 dist/**/*_test.d.ts
 tslint.json

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -62,6 +62,7 @@ function config({plugins = [], output = {}}) {
     ],
     output: {
       banner: PREAMBLE,
+      sourcemap: true,
       globals: {'@tensorflow/tfjs-core': 'tf'},
       ...output
     },


### PR DESCRIPTION
Publishing source maps to npm helps debugging, while users can still ignore them when publishing their end-user apps/bundles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/191)
<!-- Reviewable:end -->
