### PR TITLE
Fix npm bundling

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -23,6 +23,7 @@ tsconfig.json
 yarn.lock
 yarn-error.log
 python/
+package/
 DEVELOPMENT.md
 ISSUE_TEMPLATE.md
 rollup.config.js

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "@tensorflow/tfjs-converter",
   "version": "0.5.6",
   "description": "Tensorflow model converter for javascript",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "jsnext:main": "dist/tf-converter.esm.js",
   "module": "dist/tf-converter.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "unpkg": "dist/tf-converter.min.js",
   "jsdelivr": "dist/tf-converter.min.js",
   "repository": {
@@ -49,7 +49,7 @@
     "yalc": "~1.0.0-pre.21"
   },
   "scripts": {
-    "build": "tsc && copyfiles -f src/data/compiled_api.* dist/data",
+    "build": "tsc && copyfiles -f src/data/compiled_api.* dist/src/data/",
     "build-npm": "./scripts/build-npm.sh",
     "link-local": "yalc link",
     "publish-local": "yarn build-npm && yalc push",


### PR DESCRIPTION
After changing tsconfig to include two folders (`src/` and `scripts/`) in https://github.com/tensorflow/tfjs-converter/pull/189 , the `dist/` directory becomes `dist/src/`. Update package.json accordingly.

Tested by building a local tgz and using it in a vanilla npm application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/192)
<!-- Reviewable:end -->
