### PR TITLE
fixed the shape check on tensorarray scatter and split op

### DIFF
--- a/src/executor/tensor_array.ts
+++ b/src/executor/tensor_array.ts
@@ -124,7 +124,7 @@ export class TensorArray {
       this.elementShape = tensor.shape;
     }
 
-    util.assertShapesMatch(
+    this.assertShapesMatch(
         this.elementShape, tensor.shape,
         `TensorArray ${this.name}: Could not write to TensorArray index ${
             index}.`);
@@ -191,7 +191,7 @@ export class TensorArray {
     // their memory.
     const tensors = this.readMany(indices);
 
-    util.assertShapesMatch(
+    this.assertShapesMatch(
         this.elementShape, tensors[0].shape, 'TensorArray shape mismatch: ');
 
     return stack(tensors, 0);
@@ -217,7 +217,7 @@ export class TensorArray {
     // Collect all the tensors from the tensors array.
     const tensors = this.readMany(indices);
 
-    util.assertShapesMatch(
+    this.assertShapesMatch(
         this.elementShape, tensors[0].shape,
         `TensorArray shape mismatch: tensor array shape (${
             this.elementShape}) vs first tensor shape (${tensors[0].shape})`);
@@ -299,5 +299,24 @@ export class TensorArray {
       indices[i] = i;
     }
     this.writeMany(indices, tensors);
+  }
+
+  private assertShapesMatch(
+      shapeA: number[], shapeB: number[], errorMessagePrefix = ''): void {
+    util.assert(
+        this.arraysEqual(shapeA, shapeB),
+        errorMessagePrefix + ` Shapes ${shapeA} and ${shapeB} must match`);
+  }
+
+  private arraysEqual(n1: number[], n2: number[]) {
+    if (n1.length !== n2.length) {
+      return false;
+    }
+    for (let i = 0; i < n1.length; i++) {
+      if (n1[i] !== -1 && n2[i] !== -1 && n1[i] !== n2[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/src/executor/tensor_array_test.ts
+++ b/src/executor/tensor_array_test.ts
@@ -180,6 +180,14 @@ describe('TensorArray', () => {
       expect(() => tensorArray.scatter([1, 2], input)).toThrow();
     });
 
+    it('should not fail if tensor array shape is -1', () => {
+      tensorArray = new TensorArray(
+          NAME, DTYPE, SIZE, [-1, 1], IDENTICAL_SHAPE, DYNAMIC_SIZE,
+          CLEAR_AFTER_READ);
+      const input = tensor3d([1, 2, 3], [3, 1, 1], 'int32');
+      expect(() => tensorArray.scatter([1, 2, 3], input)).not.toThrow();
+    });
+
     it('should fail if max index > array max size', () => {
       const input = tensor3d([1, 2, 3], [3, 1, 1], 'int32');
       expect(() => tensorArray.scatter([1, 2, 11], input)).toThrow();
@@ -212,6 +220,14 @@ describe('TensorArray', () => {
     });
 
     it('should fail if indices and tensor shapes do not matched', () => {
+      const input = tensor3d([1, 2, 3], [3, 1, 1], 'int32');
+      expect(() => tensorArray.split([1, 1], input)).toThrow();
+    });
+
+    it('should not fail if indices and tensor shapes is -1', () => {
+      tensorArray = new TensorArray(
+          NAME, DTYPE, SIZE, [-1, 1], IDENTICAL_SHAPE, DYNAMIC_SIZE,
+          CLEAR_AFTER_READ);
       const input = tensor3d([1, 2, 3], [3, 1, 1], 'int32');
       expect(() => tensorArray.split([1, 1], input)).toThrow();
     });

--- a/src/operations/op_list/matrices.ts
+++ b/src/operations/op_list/matrices.ts
@@ -48,7 +48,7 @@ export const json = [
     'category': 'matrices',
     'params': [
       {'tfInputIndex': 0, 'dlParamName': 'x', 'type': 'tensor'},
-      {'tfParamName': 'perm', 'dlParamName': 'perm', 'type': 'number[]'}, {
+      {'tfInputIndex': 1, 'dlParamName': 'perm', 'type': 'number[]'}, {
         'tfParamName': 'T',
         'dlParamName': 'dtype',
         'type': 'dtype',


### PR DESCRIPTION
allow the tensorarray element shape to have -1 as the size.
also fixed the transpose op mapping definition.

fixed https://github.com/tensorflow/tfjs/issues/615

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/201)
<!-- Reviewable:end -->
