### PR TITLE
allow execute and executeAsync to feed the model with intermediate node

### DIFF
--- a/src/executor/frozen_model.ts
+++ b/src/executor/frozen_model.ts
@@ -143,7 +143,7 @@ export class FrozenModel implements tfc.InferenceModel {
       inputs: tfc.Tensor|tfc.Tensor[]|tfc.NamedTensorMap,
       config?: tfc.ModelPredictConfig): tfc.Tensor
       |tfc.Tensor[]|tfc.NamedTensorMap {
-    return this.execute(inputs, this.outputNodes);
+    return this.execute_(inputs, true, this.outputNodes);
   }
 
   private constructTensorMap(inputs: tfc.Tensor|tfc.Tensor[]) {
@@ -176,6 +176,13 @@ export class FrozenModel implements tfc.InferenceModel {
   execute(
       inputs: tfc.Tensor|tfc.Tensor[]|tfc.NamedTensorMap,
       outputs?: string|string[]): tfc.Tensor|tfc.Tensor[] {
+    return this.execute_(inputs, false, outputs);
+  }
+
+  private execute_(
+      inputs: tfc.Tensor|tfc.Tensor[]|tfc.NamedTensorMap,
+      strictInputCheck = true, outputs?: string|string[]): tfc.Tensor
+      |tfc.Tensor[] {
     outputs = outputs || this.outputNodes;
     if (inputs instanceof tfc.Tensor || Array.isArray(inputs)) {
       inputs = this.constructTensorMap(inputs);
@@ -186,13 +193,12 @@ export class FrozenModel implements tfc.InferenceModel {
           'please use executeAsync method');
     }
     const result = this.executor.execute(
-        this.convertTensorMapToTensorsMap(inputs), outputs);
+        this.convertTensorMapToTensorsMap(inputs), strictInputCheck, outputs);
     const keys = Object.keys(result);
     return (Array.isArray(outputs) && outputs.length > 1) ?
         outputs.map(node => result[node]) :
         result[keys[0]];
   }
-
   /**
    * Executes inference for the model for given input tensors in async
    * fashion, use this method when your model contains control flow ops.

--- a/src/executor/frozen_model_test.ts
+++ b/src/executor/frozen_model_test.ts
@@ -61,7 +61,8 @@ const SIMPLE_MODEL: tensorflow.IGraphDef = {
         length: {i: 4}
       }
     },
-    {name: 'Add', op: 'Add', input: ['Input', 'Const'], attr: {}}
+    {name: 'Add1', op: 'Add', input: ['Input', 'Const'], attr: {}},
+    {name: 'Add', op: 'Add', input: ['Add1', 'Const'], attr: {}}
   ],
   versions: {producer: 1.0, minConsumer: 3}
 };
@@ -133,21 +134,21 @@ describe('Model', () => {
         await model.load();
         const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
         const output = model.predict(input);
-        expect((output as tfc.Tensor).dataSync()[0]).toEqual(2);
+        expect((output as tfc.Tensor).dataSync()[0]).toEqual(3);
       });
 
       it('should generate the output for tensor array', async () => {
         await model.load();
         const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
         const output = model.predict([input]);
-        expect((output as tfc.Tensor).dataSync()[0]).toEqual(2);
+        expect((output as tfc.Tensor).dataSync()[0]).toEqual(3);
       });
 
       it('should generate the output for tensor map', async () => {
         await model.load();
         const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
         const output = model.predict({'Input': input});
-        expect((output as tfc.Tensor).dataSync()[0]).toEqual(2);
+        expect((output as tfc.Tensor).dataSync()[0]).toEqual(3);
       });
 
       it('should throw error if input size mismatch', async () => {
@@ -165,6 +166,12 @@ describe('Model', () => {
         const input = tfc.tensor1d([1], 'float32');
         expect(() => model.predict([input])).toThrow();
       });
+
+      it('should not allow feed intermediate node', async () => {
+        await model.load();
+        const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
+        expect(() => model.predict({'Add1': input})).toThrow();
+      });
     });
 
     describe('execute', () => {
@@ -172,14 +179,14 @@ describe('Model', () => {
         await model.load();
         const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
         const output = model.execute({'Input': input});
-        expect((output as tfc.Tensor).dataSync()[0]).toEqual(2);
+        expect((output as tfc.Tensor).dataSync()[0]).toEqual(3);
       });
       it('should generate the output array', async () => {
         await model.load();
         const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
         const output = model.execute({'Input': input}, ['Add', 'Const']);
         expect(Array.isArray(output)).toBeTruthy();
-        expect((output as tfc.Tensor[])[0].dataSync()[0]).toEqual(2);
+        expect((output as tfc.Tensor[])[0].dataSync()[0]).toEqual(3);
         expect((output as tfc.Tensor[])[1].dataSync()[0]).toEqual(1);
       });
       it('should throw exception if inputs shapes do not match', () => {
@@ -197,6 +204,13 @@ describe('Model', () => {
         const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
 
         expect(() => model.execute([input, input])).toThrow();
+      });
+
+      it('should allow feed intermediate node', async () => {
+        await model.load();
+        const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
+        const output = model.execute({'Add1': input}) as tfc.Tensor;
+        tfc.test_util.expectArraysClose(output, [2, 2]);
       });
     });
 
@@ -289,6 +303,13 @@ describe('Model', () => {
 
       expect(() => model.executeAsync([input])).not.toThrow();
     });
+
+    it('should allow feed intermediate node with executeAsync', async () => {
+      await model.load();
+      const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
+
+      expect(() => model.executeAsync({Enter: input})).not.toThrow();
+    });
   });
 
   describe('dynamic shape model', () => {
@@ -315,6 +336,13 @@ describe('Model', () => {
       const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
 
       expect(() => model.executeAsync([input])).not.toThrow();
+    });
+
+    it('should allow feed intermediate node with executeAsync', async () => {
+      await model.load();
+      const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
+
+      expect(() => model.executeAsync({Where: input})).not.toThrow();
     });
   });
 });

--- a/src/executor/graph_executor.ts
+++ b/src/executor/graph_executor.ts
@@ -32,11 +32,12 @@ interface NodeWithContexts {
 }
 
 export class GraphExecutor {
-  private compiledOrder: Node[] = [];
+  private compiledMap: Map<string, Node[]> = new Map();
   private _weightMap: NamedTensorsMap = {};
   private weightIds: number[];
   private placeholders: Node[];
   private _outputs: Node[];
+  private SEPERATOR = ',';
   get weightMap(): NamedTensorsMap {
     return this._weightMap;
   }
@@ -92,23 +93,30 @@ export class GraphExecutor {
   get isDynamicShapeModel(): boolean {
     return this.graph.withDynamicShape;
   }
+
   /**
    * Compiles the inference graph to generate the topology order of op nodes,
    * cache the result for inference execution.
    */
-  private compile() {
+  private compile(startNodes?: Node[]) {
     // Do not compile for graph with control flow, since the execution order
     // requires runtime evaluation of the output tensors.
     if (this.graph.withControlFlow || this.graph.withDynamicShape) {
       return;
     }
+    const compiledOrder = [];
+    const inputs = startNodes || this.graph.placeholders;
+    const sortedNodeNames = inputs.map(node => node.name).sort();
 
-    const stack = [...this.graph.inputs];
+    // do nothing is the compiled graph cache contains the input.
+    if (this.compiledMap.get(sortedNodeNames.join(this.SEPERATOR))) return;
+
+    const stack = [...inputs, ...this.graph.weights];
     const visited: {[key: string]: boolean} = {};
     while (stack.length > 0) {
       const node = stack.pop();
       visited[node.name] = true;
-      this.compiledOrder.push(node);
+      compiledOrder.push(node);
       node.children.forEach((childNode) => {
         if (!visited[childNode.name] && childNode.inputNames.every(name => {
               const [nodeName, ] = getNodeNameAndIndex(name);
@@ -118,6 +126,7 @@ export class GraphExecutor {
         }
       });
     }
+    this.compiledMap.set(sortedNodeNames.join(this.SEPERATOR), compiledOrder);
   }
 
   /**
@@ -129,18 +138,33 @@ export class GraphExecutor {
    * inspect intermediate nodes of the model by adding them to the outputs
    * array.
    */
-  execute(inputs: NamedTensorsMap, outputs?: string|string[]): NamedTensorMap {
-    this.checkInput(inputs);
-    this.checkInputShapeAndType(inputs);
+  execute(
+      inputs: NamedTensorsMap, strictInputCheck = true,
+      outputs?: string|string[]): NamedTensorMap {
+    const names = Object.keys(inputs).sort();
+    this.checkInput(inputs, strictInputCheck);
+    this.checkInputShapeAndType(inputs, strictInputCheck);
+
+    this.compile(names.map(name => this.graph.nodes[name]));
+    const outputNames = this.calculateOutputs(outputs);
+    this.checkOutput(
+        this.compiledMap.get(names.join(this.SEPERATOR)), outputNames);
+
     const tensorArrayMap: TensorArrayMap = {};
     const result = tidy(() => {
       const context = new ExecutionContext(this._weightMap, tensorArrayMap);
-      const tensors =
-          this.compiledOrder.reduce<NamedTensorsMap>((map, node) => {
-            map[node.name] = executeOp(node, map, context) as Tensor[];
-            return map;
-          }, {...this.weightMap, ...inputs});
-      return this.findOutputs(tensors, context, outputs);
+      const tensorMap = {...this.weightMap, ...inputs};
+      const compiledNodes = this.compiledMap.get(names.join(this.SEPERATOR));
+      for (let i = 0; i < compiledNodes.length; i++) {
+        const node = compiledNodes[i];
+        if (!tensorMap[node.name]) {
+          tensorMap[node.name] =
+              executeOp(node, tensorMap, context) as Tensor[];
+        }
+        // stop the exuection if all outputs are found.
+        if (outputNames.every(name => !!tensorMap[name])) break;
+      }
+      return this.findOutputs(tensorMap, context, outputNames);
     });
     return result;
   }
@@ -156,8 +180,8 @@ export class GraphExecutor {
    */
   async executeAsync(inputs: NamedTensorsMap, outputs?: string|string[]):
       Promise<NamedTensorMap> {
-    this.checkInput(inputs);
-    this.checkInputShapeAndType(inputs);
+    this.checkInput(inputs, false);
+    this.checkInputShapeAndType(inputs, false);
     const tensorArrayMap: TensorArrayMap = {};
     const context = new ExecutionContext(this._weightMap, tensorArrayMap);
     // Graph with control flow op requires runtime evaluation of the execution
@@ -193,13 +217,17 @@ export class GraphExecutor {
   private async executeWithControlFlow(
       inputs: NamedTensorsMap,
       context: ExecutionContext): Promise<NamedTensorsMap> {
-    const stack: NodeWithContexts[] = this.graph.inputs.map(node => {
-      return {node, contexts: context.currentContext};
-    });
+    const names = Object.keys(inputs);
+    const inputNodes = names.map(name => this.graph.nodes[name]);
+    const stack: NodeWithContexts[] =
+        [...inputNodes, ...this.graph.weights].map(node => {
+          return {node, contexts: context.currentContext};
+        });
     const tensorMap = {...this.weightMap, ...inputs};
     const added: {[key: string]: boolean} = {};
     while (stack.length > 0) {
-      const promises = this.processStack(stack, context, tensorMap, added);
+      const promises =
+          this.processStack(inputNodes, stack, context, tensorMap, added);
       await Promise.all(promises);
     }
 
@@ -207,7 +235,7 @@ export class GraphExecutor {
   }
 
   private processStack(
-      stack: NodeWithContexts[], context: ExecutionContext,
+      inputNodes: Node[], stack: NodeWithContexts[], context: ExecutionContext,
       tensorMap: NamedTensorsMap, added: {[key: string]: boolean}) {
     const promises: Array<Promise<Tensor[]>> = [];
     while (stack.length > 0) {
@@ -221,21 +249,27 @@ export class GraphExecutor {
           getParamValue('isConstant', item.node, tensorMap, context)) {
         [nodeName] = getNodeNameAndIndex(item.node.name, context);
       }
-      const tensors = executeOp(item.node, tensorMap, context);
-      if (!nodeName) {
-        [nodeName] = getNodeNameAndIndex(item.node.name, context);
-      }
 
-      const currentContext = context.currentContext;
-      if (tensors instanceof Promise) {
-        promises.push(tensors.then(t => {
-          tensorMap[nodeName] = t;
-          context.currentContext = currentContext;
+      // only process nodes that are not provided as input nodes.
+      if (inputNodes.indexOf(item.node) === -1) {
+        const tensors = executeOp(item.node, tensorMap, context);
+        if (!nodeName) {
+          [nodeName] = getNodeNameAndIndex(item.node.name, context);
+        }
+
+        const currentContext = context.currentContext;
+        if (tensors instanceof Promise) {
+          promises.push(tensors.then(t => {
+            tensorMap[nodeName] = t;
+            context.currentContext = currentContext;
+            this.processChildNodes(item.node, stack, context, tensorMap, added);
+            return t;
+          }));
+        } else {
+          tensorMap[nodeName] = tensors;
           this.processChildNodes(item.node, stack, context, tensorMap, added);
-          return t;
-        }));
+        }
       } else {
-        tensorMap[nodeName] = tensors;
         this.processChildNodes(item.node, stack, context, tensorMap, added);
       }
     }
@@ -267,15 +301,17 @@ export class GraphExecutor {
     });
   }
 
-  private findOutputs(
-      tensorMap: NamedTensorsMap, context: ExecutionContext,
-      outputs?: string|string[]): NamedTensorMap {
+  private calculateOutputs(outputs?: string|string[]): string[] {
     if (outputs && !(outputs instanceof Array)) {
       outputs = [outputs];
     }
-    const requestedOutputs =
-        (outputs || this.graph.outputs.map(node => node.name)) as string[];
+    return (outputs || this.graph.outputs.map(node => node.name)) as string[];
+  }
 
+  private findOutputs(
+      tensorMap: NamedTensorsMap, context: ExecutionContext,
+      outputs?: string|string[]): NamedTensorMap {
+    const requestedOutputs = this.calculateOutputs(outputs);
     return requestedOutputs.reduce<NamedTensorMap>((map, name) => {
       map[name] = getTensor(name, tensorMap, context);
       return map;
@@ -290,9 +326,15 @@ export class GraphExecutor {
             key => this.weightMap[key].forEach(tensor => tensor.dispose()));
   }
 
-  private checkInputShapeAndType(inputs: NamedTensorsMap) {
+  private checkInputShapeAndType(
+      inputs: NamedTensorsMap, strictInputCheck = true) {
     this.placeholders.forEach(node => {
-      const input = inputs[node.name][0];
+      const inputTensors = inputs[node.name];
+      // do nothing if no strick input check and input tensors is not for the
+      // placehloder.
+      if (!strictInputCheck && !inputTensors) return;
+
+      const input = inputTensors[0];
       if (node.params['shape'] && node.params['shape'].value) {
         const shape = node.params['shape'].value as number[];
         const match = shape.length === input.shape.length &&
@@ -314,7 +356,7 @@ export class GraphExecutor {
     });
   }
 
-  private checkInput(inputs: NamedTensorsMap) {
+  private checkInput(inputs: NamedTensorsMap, strictInputCheck = true) {
     const inputKeys = Object.keys(inputs);
     const missing: string[] = [];
     const extra: string[] = [];
@@ -327,17 +369,31 @@ export class GraphExecutor {
       if (this.inputNodes.indexOf(name) === -1) extra.push(name);
     });
 
-    if (missing.length > 0) {
+    if (missing.length > 0 && strictInputCheck) {
       throw new Error(
           `The dict provided in model.execute(dict) has the keys ` +
           `[${inputKeys}], but is missing the required keys: [${missing}].`);
     }
 
-    if (extra.length > 0) {
+    if (extra.length > 0 && strictInputCheck) {
       throw new Error(
           `The dict provided in model.execute(dict) has ` +
           `unused keys: [${extra}]. Please provide only the following keys: ` +
           `[${this.inputNodes}].`);
+    }
+  }
+
+  private checkOutput(compiledNodes: Node[], outputs: string[]) {
+    const compiledNodeNames = compiledNodes.map(node => node.name);
+    const extra: string[] = [];
+    outputs.forEach(name => {
+      if (compiledNodeNames.indexOf(name) === -1) extra.push(name);
+    });
+
+    if (extra.length > 0) {
+      throw new Error(
+          `The following outputs cannot be generated by the inputs: ` +
+          `[${extra}].`);
     }
   }
 }

--- a/src/executor/graph_executor_test.ts
+++ b/src/executor/graph_executor_test.ts
@@ -18,15 +18,14 @@
 import * as tfc from '@tensorflow/tfjs-core';
 
 import {createTensorAttr} from '../operations/executors/test_helper';
-import * as operations from '../operations/operation_executor';
 import {Graph, Node} from '../operations/types';
 
-import {ExecutionContext} from './execution_context';
 import {GraphExecutor} from './graph_executor';
 
 let executor: GraphExecutor;
 let inputNode: Node;
 let constNode: Node;
+let intermediateNode: Node;
 let outputNode: Node;
 let graph: Graph;
 let graphWithControlFlow: Graph;
@@ -52,9 +51,18 @@ describe('GraphExecutor', () => {
       category: 'graph',
       params: {}
     };
-    outputNode = {
+    intermediateNode = {
       inputNames: ['input', 'const'],
       inputs: [inputNode, constNode],
+      children: [],
+      name: 'intermediate',
+      op: 'add',
+      category: 'arithmetic',
+      params: {'a': createTensorAttr(0), 'b': createTensorAttr(1)}
+    };
+    outputNode = {
+      inputNames: ['intermediate', 'const'],
+      inputs: [intermediateNode, constNode],
       children: [],
       name: 'output',
       op: 'add',
@@ -63,16 +71,23 @@ describe('GraphExecutor', () => {
     };
     graph = {
       inputs: [constNode, inputNode],
-      nodes: {'input': inputNode, 'const': constNode, 'output': outputNode},
+      nodes: {
+        'input': inputNode,
+        'const': constNode,
+        'intermediate': intermediateNode,
+        'output': outputNode
+      },
       outputs: [outputNode],
+      weights: [constNode],
       withControlFlow: false,
       withDynamicShape: false,
       placeholders: [inputNode]
     };
-    inputNode.children.push(outputNode);
-    constNode.children.push(outputNode);
+    inputNode.children.push(intermediateNode);
+    constNode.children.push(intermediateNode, outputNode);
+    intermediateNode.children.push(outputNode);
     executor = new GraphExecutor(graph);
-    constTensor = tfc.scalar(2);
+    constTensor = tfc.scalar(2.0);
     executor.weightMap = {'const': [constTensor]};
   });
   afterEach(() => {});
@@ -106,56 +121,94 @@ describe('GraphExecutor', () => {
 
     describe('graph level', () => {
       describe('execute', () => {
-        it('should throw exception if missing inputs', () => {
-          expect(() => executor.execute({}))
-              .toThrow(new Error(
-                  'The dict provided in model.execute(dict) has the keys [], ' +
-                  'but is missing the required keys: [input].'));
-        });
-
-        it('should throw exception if contains extra inputs', () => {
-          const inputTensor = tfc.scalar(1);
-          expect(
-              () =>
-                  executor.execute({test: [inputTensor], input: [inputTensor]}))
-              .toThrow(new Error(
-                  'The dict provided in model.execute(dict) has unused keys: ' +
-                  '[test]. Please provide only the following keys: [input].'));
-        });
-
         it('should execute the op', () => {
-          executor = new GraphExecutor(graph);
           const inputTensor = tfc.scalar(1);
-          const spy =
-              spyOn(operations, 'executeOp').and.callFake((node: Node) => {
-                return node.op === 'const' ? [constTensor] : [inputTensor];
-              });
 
-          executor.execute({input: [inputTensor]});
-
-          expect(spy.calls.allArgs()).toEqual([
-            [inputNode, jasmine.any(Object), jasmine.any(ExecutionContext)],
-            [constNode, jasmine.any(Object), jasmine.any(ExecutionContext)],
-            [outputNode, jasmine.any(Object), jasmine.any(ExecutionContext)]
-          ]);
+          const result = executor.execute({input: [inputTensor]});
+          tfc.test_util.expectArraysClose(result['output'], [5.0]);
         });
 
-        it('should throw exception if inputs shapes do not match graph', () => {
-          inputNode.params['shape'] = {value: [1, 1], type: 'shape'};
-          const inputTensor = tfc.tensor1d([1], 'float32');
-          expect(() => executor.execute({input: [inputTensor]}))
-              .toThrow(new Error(
-                  'The shape of dict[\'input\'] provided' +
-                  ' in model.execute(dict) must be [1,1], but was [1]'));
+        it('should allow feed intermediate nodes', () => {
+          const intermediateTensor = tfc.scalar(1);
+          const result =
+              executor.execute({intermediate: [intermediateTensor]}, false);
+          tfc.test_util.expectArraysClose(result['output'], [3.0]);
         });
 
-        it('should throw exception if inputs dtype do not match graph', () => {
-          inputNode.params['dtype'] = {value: 'int32', type: 'dtype'};
-          const inputTensor = tfc.tensor1d([1], 'float32');
-          expect(() => executor.execute({input: [inputTensor]}))
-              .toThrow(new Error(
-                  'The dtype of dict[\'input\'] provided' +
-                  ' in model.execute(dict) must be int32, but was float32'));
+        describe('strict input check', () => {
+          it('should throw exception if missing inputs', () => {
+            expect(() => executor.execute({}))
+                .toThrow(new Error(
+                    'The dict provided in model.execute(dict) ' +
+                    'has the keys [], but is missing the required' +
+                    ' keys: [input].'));
+          });
+
+          it('should throw exception if contains extra inputs', () => {
+            const inputTensor = tfc.scalar(1);
+            expect(
+                () => executor.execute(
+                    {test: [inputTensor], input: [inputTensor]}, true))
+                .toThrow(new Error(
+                    'The dict provided in model.execute(dict)' +
+                    ' has unused keys: [test]. Please provide' +
+                    ' only the following keys: [input].'));
+          });
+
+          it('should throw exception if inputs shapes mismatch', () => {
+            inputNode.params['shape'] = {value: [1, 1], type: 'shape'};
+            const inputTensor = tfc.tensor1d([1], 'float32');
+            expect(() => executor.execute({input: [inputTensor]}))
+                .toThrow(new Error(
+                    'The shape of dict[\'input\'] provided' +
+                    ' in model.execute(dict) must be [1,1], but was [1]'));
+          });
+
+          it('should throw exception for dtype mismatch', () => {
+            inputNode.params['dtype'] = {value: 'int32', type: 'dtype'};
+            const inputTensor = tfc.tensor1d([1], 'float32');
+            expect(() => executor.execute({input: [inputTensor]}))
+                .toThrow(new Error(
+                    'The dtype of dict[\'input\'] provided' +
+                    ' in model.execute(dict) must be int32, but was float32'));
+          });
+        });
+        describe('non strict input check', () => {
+          it('should not throw exception if missing inputs', () => {
+            expect(() => executor.execute({}, false))
+                .not.toThrow(new Error(
+                    'The dict provided in model.execute(dict) ' +
+                    'has the keys [], but is missing the required' +
+                    ' keys: [input].'));
+          });
+
+          it('should not throw exception if contains extra inputs', () => {
+            const inputTensor = tfc.scalar(1);
+            expect(
+                () => executor.execute(
+                    {test: [inputTensor], input: [inputTensor]}, false))
+                .not.toThrow(new Error(
+                    'The dict provided in model.execute(dict)' +
+                    ' has unused keys: [test]. Please provide' +
+                    ' only the following keys: [input].'));
+          });
+          it('should throw exception if inputs shapes mismatch', () => {
+            inputNode.params['shape'] = {value: [1, 1], type: 'shape'};
+            const inputTensor = tfc.tensor1d([1], 'float32');
+            expect(() => executor.execute({input: [inputTensor]}, false))
+                .toThrow(new Error(
+                    'The shape of dict[\'input\'] provided' +
+                    ' in model.execute(dict) must be [1,1], but was [1]'));
+          });
+
+          it('should throw exception dtype mismatch', () => {
+            inputNode.params['dtype'] = {value: 'int32', type: 'dtype'};
+            const inputTensor = tfc.tensor1d([1], 'float32');
+            expect(() => executor.execute({input: [inputTensor]}, false))
+                .toThrow(new Error(
+                    'The dtype of dict[\'input\'] provided' +
+                    ' in model.execute(dict) must be int32, but was float32'));
+          });
         });
 
         it('should not throw exception if inputs shapes is dynamic', () => {
@@ -166,7 +219,7 @@ describe('GraphExecutor', () => {
       });
 
       describe('executeAsync', () => {
-        it('should execute control flow graph', async (done) => {
+        beforeEach(() => {
           inputNode = {
             inputNames: [],
             inputs: [],
@@ -185,45 +238,76 @@ describe('GraphExecutor', () => {
             category: 'graph',
             params: {}
           };
-          outputNode = {
+          intermediateNode = {
             inputNames: ['input', 'const'],
             inputs: [inputNode, constNode],
+            children: [],
+            name: 'intermediate',
+            op: 'add',
+            category: 'arithmetic',
+            params: {'a': createTensorAttr(0), 'b': createTensorAttr(1)}
+          };
+          outputNode = {
+            inputNames: ['const', 'intermediate'],
+            inputs: [constNode, intermediateNode],
             children: [],
             name: 'output',
             op: 'switch',
             category: 'control',
-            params: {}
+            params: {'pred': createTensorAttr(0), 'data': createTensorAttr(1)}
           };
-          inputNode.children.push(outputNode);
-          constNode.children.push(outputNode);
+          inputNode.children.push(intermediateNode);
+          constNode.children.push(intermediateNode, outputNode);
+          intermediateNode.children.push(outputNode);
           graphWithControlFlow = {
             inputs: [constNode, inputNode],
-            nodes:
-                {'input': inputNode, 'const': constNode, 'output': outputNode},
+            nodes: {
+              'input': inputNode,
+              'const': constNode,
+              'intermediate': intermediateNode,
+              'output': outputNode
+            },
             outputs: [outputNode],
+            weights: [constNode],
             withControlFlow: true,
             withDynamicShape: false,
             placeholders: [inputNode]
           };
 
           executor = new GraphExecutor(graphWithControlFlow);
-          const inputTensor = tfc.scalar(1);
-          const constTensor = tfc.scalar(2);
           executor.weightMap = {const : [constTensor]};
-          const spy =
-              spyOn(operations, 'executeOp').and.callFake((node: Node) => {
-                return node.op === 'const' ? [constTensor] : [inputTensor];
-              });
-
-          await executor.executeAsync({input: [inputTensor]}).then(result => {
-            expect(spy.calls.allArgs()).toEqual([
-              [inputNode, jasmine.any(Object), jasmine.any(ExecutionContext)],
-              [outputNode, jasmine.any(Object), jasmine.any(ExecutionContext)],
-              [constNode, jasmine.any(Object), jasmine.any(ExecutionContext)],
-            ]);
-            done();
-          });
         });
+
+        it('should execute control flow graph', (done) => {
+          const inputTensor = tfc.scalar(1);
+
+          executor.executeAsync({input: [inputTensor]}, 'output:1')
+              .then(
+                  result => {
+                    tfc.test_util.expectArraysClose(result['output:1'], [3]);
+                    done();
+                  },
+                  e => {
+                    fail(e);
+                    done();
+                  });
+        });
+
+        it('should execute control flow graph with intermediate node',
+           (done) => {
+             const inputTensor = tfc.scalar(1);
+
+             executor.executeAsync({intermediate: [inputTensor]}, 'output:1')
+                 .then(
+                     result => {
+                       tfc.test_util.expectArraysClose(result['output:1'], [1]);
+                       done();
+                     },
+                     e => {
+                       fail(e);
+                       done();
+                     });
+           });
       });
     });
   });

--- a/src/operations/operation_mapper.ts
+++ b/src/operations/operation_mapper.ts
@@ -81,11 +81,13 @@ export class OperationMapper {
     let withControlFlow = false;
     let withDynamicShape = false;
     const placeholders: Node[] = [];
+    const weights: Node[] = [];
     const nodes = tfNodes.reduce<{[key: string]: Node}>((map, node) => {
       map[node.name] = this.mapNode(node);
       if (this.isControlFlow(node)) withControlFlow = true;
       if (this.isDynamicShape(node)) withDynamicShape = true;
       if (node.op === 'Placeholder') placeholders.push(map[node.name]);
+      if (node.op === 'Const') weights.push(map[node.name]);
       return map;
     }, {});
 
@@ -105,10 +107,12 @@ export class OperationMapper {
       const node = nodes[key];
       if (node.children.length === 0) outputs.push(node);
     });
+
     return {
       nodes,
       inputs,
       outputs,
+      weights,
       placeholders,
       withControlFlow,
       withDynamicShape

--- a/src/operations/operation_mapper_test.ts
+++ b/src/operations/operation_mapper_test.ts
@@ -138,6 +138,12 @@ describe('operationMapper', () => {
         ]);
       });
 
+      it('should find the graph weight nodes', () => {
+        expect(graph.weights.map(node => node.name)).toEqual([
+          'Const', 'Shape', 'Value'
+        ]);
+      });
+
       it('should convert nodes', () => {
         expect(Object.keys(graph.nodes)).toEqual([
           'image_placeholder', 'Const', 'Shape', 'Value', 'Fill', 'Conv2D',

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -54,6 +54,7 @@ export declare interface Graph {
   placeholders: Node[];
   inputs: Node[];
   outputs: Node[];
+  weights: Node[];
   withControlFlow: boolean;
   withDynamicShape: boolean;
 }


### PR DESCRIPTION
Allow feeding the frozen model with intermediate nodes for prediction, which is typical for dynamic_rnn model. fixes https://github.com/tensorflow/tfjs/issues/532

The execute and executeAsync methods will allow feeding intermediate nodes, while predict method will stay consistent with layers API that only allows feeding input nodes.