### PR TITLE
Corrected tensorflow "module" operation name

### DIFF
--- a/src/operations/op_list/arithmetic.ts
+++ b/src/operations/op_list/arithmetic.ts
@@ -172,7 +172,7 @@ export const json = [
     ]
   },
   {
-    'tfOpName': 'Mod',
+    'tfOpName': 'FloorMod',
     'dlOpName': 'mod',
     'category': 'arithmetic',
     'params': [


### PR DESCRIPTION
In tensorflow the module operation is called FloorMod and not Mod.
This error will cause the converter to throw an error if it finds any module operation in the graph.

https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/math_ops.py#L1121