### PR TITLE
support aggressive intermediate tensor disposal

### DIFF
--- a/src/executor/graph_executor.ts
+++ b/src/executor/graph_executor.ts
@@ -192,7 +192,10 @@ export class GraphExecutor {
       intermediateTensorConsumerCount: {[key: string]: number}) {
     // Skip any control flow nodes, since its dependency is tricky to track
     // correctly.
-    if (node.category === 'control') return;
+    if (node.category === 'control') {
+      return;
+    }
+
     tensorMap[nodeName].forEach(tensor => {
       if (tensor != null) {
         intermediateTensorConsumerCount[tensor.id] =

--- a/src/executor/graph_executor.ts
+++ b/src/executor/graph_executor.ts
@@ -20,7 +20,7 @@ import {DataType, Tensor, tidy, util} from '@tensorflow/tfjs-core';
 // tslint:disable-next-line:max-line-length
 import {NamedTensorMap, NamedTensorsMap, TensorArrayMap, TensorInfo} from '../data/types';
 // tslint:disable-next-line:max-line-length
-import {getNodeNameAndIndex, getParamValue, getTensor} from '../operations/executors/utils';
+import {getNodeNameAndIndex, getParamValue, getTensor, getTensorsForCurrentContenxt} from '../operations/executors/utils';
 import {executeOp} from '../operations/operation_executor';
 import {Graph, Node} from '../operations/types';
 
@@ -157,12 +157,18 @@ export class GraphExecutor {
     const result = tidy(() => {
       const context = new ExecutionContext(this._weightMap, tensorArrayMap);
       const tensorMap = {...this.weightMap, ...inputs};
+      const tensorsToKeep = this.getFrozenTensorIds(tensorMap);
+      const intermediateTensorConsumerCount: {[key: number]: number} = {};
+
       const compiledNodes = this.compiledMap.get(names.join(this.SEPERATOR));
       for (let i = 0; i < compiledNodes.length; i++) {
         const node = compiledNodes[i];
         if (!tensorMap[node.name]) {
           tensorMap[node.name] =
               executeOp(node, tensorMap, context) as Tensor[];
+          this.checkTensorForDisposal(
+              node.name, node, tensorMap, context, tensorsToKeep,
+              intermediateTensorConsumerCount);
         }
         // stop the execution if all outputs are found.
         if (outputNames.every(name => !!tensorMap[name])) {
@@ -174,6 +180,49 @@ export class GraphExecutor {
     return result;
   }
 
+  private getFrozenTensorIds(tensorMap: NamedTensorsMap): Set<number> {
+    const ids = Object.keys(tensorMap)
+                    .map(key => tensorMap[key])
+                    .map(tensors => tensors.map(tensor => tensor.id));
+    return new Set([].concat(...ids));
+  }
+  private checkTensorForDisposal(
+      nodeName: string, node: Node, tensorMap: NamedTensorsMap,
+      context: ExecutionContext, tensorsToKeep: Set<number>,
+      intermediateTensorConsumerCount: {[key: string]: number}) {
+    // Skip any control flow nodes, since its dependency is tricky to track
+    // correctly.
+    if (node.category === 'control') return;
+    tensorMap[nodeName].forEach(tensor => {
+      if (tensor) {
+        intermediateTensorConsumerCount[tensor.id] =
+            (intermediateTensorConsumerCount[tensor.id] || 0) +
+            node.children.length;
+      }
+    });
+    node.inputs.forEach(input => {
+      // Skip any control flow nodes, since its dependency is tricky to track
+      // correctly.
+      if (input.category !== 'control') {
+        const tensors =
+            getTensorsForCurrentContenxt(input.name, tensorMap, context);
+        if (tensors) {
+          tensors.forEach(tensor => {
+            if (tensor && !tensorsToKeep.has(tensor.id)) {
+              const count = intermediateTensorConsumerCount[tensor.id];
+              if (count === 1) {
+                tensor.dispose();
+                delete intermediateTensorConsumerCount[tensor.id];
+              } else if (!!count) {
+                intermediateTensorConsumerCount[tensor.id] =
+                    intermediateTensorConsumerCount[tensor.id] - 1;
+              }
+            }
+          });
+        }
+      }
+    });
+  }
   /**
    * Executes the inference for given input tensors in Async fashion.
    * @param inputs Tensor map for the model inputs, keyed by the input node
@@ -229,10 +278,13 @@ export class GraphExecutor {
           return {node, contexts: context.currentContext};
         });
     const tensorMap = {...this.weightMap, ...inputs};
+    const intermediateTensorConsumerCount: {[key: number]: number} = {};
+    const tensorsToKeep = this.getFrozenTensorIds(tensorMap);
     const added: {[key: string]: boolean} = {};
     while (stack.length > 0) {
-      const promises =
-          this.processStack(inputNodes, stack, context, tensorMap, added);
+      const promises = this.processStack(
+          inputNodes, stack, context, tensorMap, added, tensorsToKeep,
+          intermediateTensorConsumerCount);
       await Promise.all(promises);
     }
 
@@ -241,7 +293,9 @@ export class GraphExecutor {
 
   private processStack(
       inputNodes: Node[], stack: NodeWithContexts[], context: ExecutionContext,
-      tensorMap: NamedTensorsMap, added: {[key: string]: boolean}) {
+      tensorMap: NamedTensorsMap, added: {[key: string]: boolean},
+      tensorsToKeep: Set<number>,
+      intermediateTensorConsumerCount: {[key: number]: number}) {
     const promises: Array<Promise<Tensor[]>> = [];
     while (stack.length > 0) {
       const item = stack.pop();
@@ -267,11 +321,17 @@ export class GraphExecutor {
           promises.push(tensors.then(t => {
             tensorMap[nodeName] = t;
             context.currentContext = currentContext;
+            this.checkTensorForDisposal(
+                nodeName, item.node, tensorMap, context, tensorsToKeep,
+                intermediateTensorConsumerCount);
             this.processChildNodes(item.node, stack, context, tensorMap, added);
             return t;
           }));
         } else {
           tensorMap[nodeName] = tensors;
+          this.checkTensorForDisposal(
+              nodeName, item.node, tensorMap, context, tensorsToKeep,
+              intermediateTensorConsumerCount);
           this.processChildNodes(item.node, stack, context, tensorMap, added);
         }
       } else {

--- a/src/executor/graph_executor.ts
+++ b/src/executor/graph_executor.ts
@@ -192,7 +192,7 @@ export class GraphExecutor {
       intermediateTensorConsumerCount: {[key: string]: number}) {
     // Skip any control flow nodes, since its dependency is tricky to track
     // correctly.
-    if (node.category === 'control') return new Set();
+    if (node.category === 'control') return;
     tensorMap[nodeName].forEach(tensor => {
       if (tensor != null) {
         intermediateTensorConsumerCount[tensor.id] =

--- a/src/operations/executors/control_executor.ts
+++ b/src/operations/executors/control_executor.ts
@@ -17,7 +17,6 @@
 
 import * as tfc from '@tensorflow/tfjs-core';
 import {scalar} from '@tensorflow/tfjs-core';
-import {test_util} from '@tensorflow/tfjs-core';
 
 import {NamedTensorsMap} from '../../data/types';
 import {ExecutionContext} from '../../executor/execution_context';

--- a/src/operations/executors/control_executor.ts
+++ b/src/operations/executors/control_executor.ts
@@ -17,6 +17,7 @@
 
 import * as tfc from '@tensorflow/tfjs-core';
 import {scalar} from '@tensorflow/tfjs-core';
+import {test_util} from '@tensorflow/tfjs-core';
 
 import {NamedTensorsMap} from '../../data/types';
 import {ExecutionContext} from '../../executor/execution_context';
@@ -30,19 +31,23 @@ export async function executeOp(
     context: ExecutionContext): Promise<tfc.Tensor[]> {
   switch (node.op) {
     case 'loopCond':
-      return [getParamValue('pred', node, tensorMap, context) as tfc.Tensor];
+      return [
+        (getParamValue('pred', node, tensorMap, context) as tfc.Tensor).clone()
+      ];
     case 'switch': {
       const pred =
           getParamValue('pred', node, tensorMap, context) as tfc.Tensor;
       const data =
           getParamValue('data', node, tensorMap, context) as tfc.Tensor;
       // Outputs nodes :0 => false, :1 => true
-      return (await pred.data())[0] ? [undefined, data] : [data, undefined];
+      return (await pred.data())[0] ? [undefined, data.clone()] :
+                                      [data.clone(), undefined];
     }
     case 'merge':
       const inputName = node.inputNames.find(
           name => getTensor(name, tensorMap, context) !== undefined);
-      return inputName ? [getTensor(inputName, tensorMap, context)] : undefined;
+      return inputName ? [getTensor(inputName, tensorMap, context).clone()] :
+                         undefined;
 
     case 'enter':
       const frameId =
@@ -50,19 +55,19 @@ export async function executeOp(
       const data =
           getParamValue('tensor', node, tensorMap, context) as tfc.Tensor;
       context.enterFrame(frameId);
-      return [data];
+      return [data.clone()];
 
     case 'exit':
       const tensor =
           getParamValue('tensor', node, tensorMap, context) as tfc.Tensor;
       context.exitFrame();
-      return [tensor];
+      return [tensor.clone()];
 
     case 'nextIteration':
       const input =
           getParamValue('tensor', node, tensorMap, context) as tfc.Tensor;
       context.nextIteration();
-      return [input];
+      return [input.clone()];
 
     case 'tensorArray':
       const size = getParamValue('size', node, tensorMap, context) as number;

--- a/src/operations/executors/control_executor_test.ts
+++ b/src/operations/executors/control_executor_test.ts
@@ -16,7 +16,7 @@
  */
 import * as tfc from '@tensorflow/tfjs-core';
 import {scalar, tensor1d, tensor2d} from '@tensorflow/tfjs-core';
-import {expectArraysClose} from '@tensorflow/tfjs-core/dist/test_util';
+import {test_util} from '@tensorflow/tfjs-core';
 
 import {ExecutionContext} from '../../executor/execution_context';
 import {TensorArray} from '../../executor/tensor_array';
@@ -52,9 +52,9 @@ describe('control', () => {
         node.params['data'] = createTensorAttr(0);
 
         const pred = [tfc.scalar(true)];
-        expect(await executeOp(node, {pred, input1}, context)).toEqual([
-          undefined, input1[0]
-        ]);
+        const result = await executeOp(node, {pred, input1}, context);
+        expect(result[0]).toBeUndefined();
+        test_util.expectArraysEqual(result[1], input1[0]);
       });
       it('should set the output condition is false', async () => {
         node.op = 'switch';
@@ -62,9 +62,9 @@ describe('control', () => {
         node.params['data'] = createTensorAttr(0);
 
         const pred = [tfc.scalar(false)];
-        expect(await executeOp(node, {pred, input1}, context)).toEqual([
-          input1[0], undefined
-        ]);
+        const result = await executeOp(node, {pred, input1}, context);
+        test_util.expectArraysEqual(result[0], input1[0]);
+        expect(result[1]).toBeUndefined();
       });
       it('should match json def', () => {
         node.op = 'switch';
@@ -79,10 +79,12 @@ describe('control', () => {
         node.op = 'merge';
 
         const pred = [tfc.scalar(true)];
-        expect(await executeOp(node, {pred: undefined, input1}, context))
-            .toEqual(input1);
-        expect(await executeOp(node, {pred, input1: undefined}, context))
-            .toEqual(pred);
+        test_util.expectArraysEqual(
+            (await executeOp(node, {pred: undefined, input1}, context))[0],
+            input1[0]);
+        test_util.expectArraysEqual(
+            (await executeOp(node, {pred, input1: undefined}, context))[0],
+            pred[0]);
       });
       it('should return undefined if no inputs are available', async () => {
         node.op = 'merge';
@@ -104,7 +106,8 @@ describe('control', () => {
         node.params['tensor'] = createTensorAttr(0);
         node.inputNames = ['input1'];
 
-        expect(await executeOp(node, {input1}, context)).toEqual(input1);
+        test_util.expectArraysEqual(
+            (await executeOp(node, {input1}, context))[0], input1[0]);
         expect(context.enterFrame).toHaveBeenCalled();
       });
       it('should match json def', () => {
@@ -121,7 +124,8 @@ describe('control', () => {
         node.params['tensor'] = createTensorAttr(0);
         node.inputNames = ['input1'];
 
-        expect(await executeOp(node, {input1}, context)).toEqual(input1);
+        test_util.expectArraysEqual(
+            (await executeOp(node, {input1}, context))[0], input1[0]);
         expect(context.exitFrame).toHaveBeenCalled();
       });
       it('should match json def', () => {
@@ -138,7 +142,8 @@ describe('control', () => {
         node.params['tensor'] = createTensorAttr(0);
         node.inputNames = ['input1'];
 
-        expect(await executeOp(node, {input1}, context)).toEqual(input1);
+        test_util.expectArraysEqual(
+            (await executeOp(node, {input1}, context))[0], input1[0]);
         expect(context.nextIteration).toHaveBeenCalled();
       });
       it('should match json def', () => {
@@ -218,7 +223,7 @@ describe('control', () => {
         const input3 = [scalar(0)];
         const read = await executeOp(node, {input1, input2, input3}, context);
 
-        expectArraysClose(read[0], input4);
+        test_util.expectArraysClose(read[0], input4);
       });
       it('should match json def', () => {
         node.op = 'tensorArrayRead';
@@ -247,7 +252,7 @@ describe('control', () => {
         const gather = await executeOp(node, {input2, input3}, context);
         expect(gather.length).toEqual(1);
         expect(gather[0].shape).toEqual([2, 3]);
-        expectArraysClose(
+        test_util.expectArraysClose(
             gather[0].dataSync(), new Int32Array([0, 0, 0, 1, 1, 1]));
       });
       it('should match json def', () => {
@@ -331,7 +336,7 @@ describe('control', () => {
         const concat = await executeOp(node, {input2}, context);
         expect(concat.length).toEqual(1);
         expect(concat[0].shape).toEqual([6]);
-        expectArraysClose(
+        test_util.expectArraysClose(
             concat[0].dataSync(), new Int32Array([0, 0, 0, 1, 1, 1]));
       });
       it('should match json def', () => {
@@ -358,7 +363,7 @@ describe('control', () => {
         const size = await executeOp(node, {input2}, context);
         expect(size.length).toEqual(1);
         expect(size[0].shape).toEqual([]);
-        expectArraysClose(size[0].dataSync(), new Int32Array([2]));
+        test_util.expectArraysClose(size[0].dataSync(), new Int32Array([2]));
       });
       it('should match json def', () => {
         node.op = 'tensorArraySize';

--- a/src/operations/executors/graph_executor.ts
+++ b/src/operations/executors/graph_executor.ts
@@ -38,7 +38,9 @@ export let executeOp: OpExecutor = (node: Node, tensorMap: NamedTensorsMap,
     case 'identity':
     case 'stopGradient':
     case 'fakeQuantWithMinMaxVars':  // This op is currently ignored.
-      return [getParamValue('x', node, tensorMap, context) as tfc.Tensor];
+      return [
+        (getParamValue('x', node, tensorMap, context) as tfc.Tensor).clone()
+      ];
     case 'snapshot':
       const snapshot =
           (getParamValue('x', node, tensorMap, context) as tfc.Tensor);

--- a/src/operations/executors/graph_executor_test.ts
+++ b/src/operations/executors/graph_executor_test.ts
@@ -67,7 +67,9 @@ describe('graph', () => {
         node.inputNames = ['input'];
         node.params.x = createTensorAttr(0);
         node.op = 'identity';
-        expect(executeOp(node, {input: input1}, context)).toEqual(input1);
+        test_util.expectArraysEqual(
+            (executeOp(node, {input: input1}, context) as tfc.Tensor[])[0],
+            input1[0]);
       });
     });
     describe('snapshot', () => {
@@ -158,7 +160,9 @@ describe('graph', () => {
       node.inputNames = ['input'];
       node.params.x = createTensorAttr(0);
       node.op = 'stopGradient';
-      expect(executeOp(node, {input: input1}, context)).toEqual(input1);
+      test_util.expectArraysClose(
+          (executeOp(node, {input: input1}, context) as tfc.Tensor[])[0],
+          input1[0]);
     });
   });
   describe('fakeQuantWithMinMaxVars', () => {
@@ -166,7 +170,9 @@ describe('graph', () => {
       node.inputNames = ['input'];
       node.params.x = createTensorAttr(0);
       node.op = 'fakeQuantWithMinMaxVars';
-      expect(executeOp(node, {input: input1}, context)).toEqual(input1);
+      test_util.expectArraysClose(
+          (executeOp(node, {input: input1}, context) as tfc.Tensor[])[0],
+          input1[0]);
     });
   });
 });

--- a/src/operations/executors/utils.ts
+++ b/src/operations/executors/utils.ts
@@ -68,6 +68,17 @@ export function getTensor(
 }
 
 /**
+ * Retrieve the tensors based on input name for current context.
+ * @param name Node input name
+ * @param tensorsMap Tensors map keyed by the node
+ */
+export function getTensorsForCurrentContenxt(
+    name: string, tensorsMap: NamedTensorsMap,
+    context: ExecutionContext): tfc.Tensor[] {
+  return tensorsMap[getNodeNameWithContextId(name, context.currentContextId)];
+}
+
+/**
  * Returns the node name and index from the Node input name.
  * @param inputName The input name of the node, in format of
  * node_name:output_index, i.e. MatMul:0, if the output_index is not set, it is

--- a/src/operations/op_list/arithmetic.ts
+++ b/src/operations/op_list/arithmetic.ts
@@ -184,5 +184,19 @@ export const json = [
         'notSupported': true
       }
     ]
+  },
+  {
+    'tfOpName': 'FloorMod',
+    'dlOpName': 'mod',
+    'category': 'arithmetic',
+    'params': [
+      {'tfInputIndex': 0, 'dlParamName': 'a', 'type': 'tensor'},
+      {'tfInputIndex': 1, 'dlParamName': 'b', 'type': 'tensor'}, {
+        'tfParamName': 'T',
+        'dlParamName': 'dtype',
+        'type': 'dtype',
+        'notSupported': true
+      }
+    ]
   }
 ];


### PR DESCRIPTION
fix https://github.com/tensorflow/tfjs/issues/719

Ref count is used to track each tensor, the ref count is determined by the dependent node.
The ref count is decreased when any of dependent nodes is executed. There is a main caveat for
graph with control flow op, we will only decrease the parent ref count, if it is in the same execution
context as the child node.
 
To determine if an tensor is ready to be disposed, following rules are checked:

1. The tensor is not input or weight tensors
2. The tensor ref count is 0
3. The tensor is not an output of a control flow type node

|DeepLabV3 model |peak GPU memory (bytes)|
|-|-|
|before|1326701472|
|after|73078664|
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/214)
<!-- Reviewable:end -->
