### PR TITLE
Add device allocation optimizer

### DIFF
--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -16,6 +16,7 @@
  */
 import {DataType, Tensor} from '@tensorflow/tfjs-core';
 import {TensorArray} from '../executor/tensor_array';
+import {Graph} from '../operations/types';
 
 export type NamedTensorMap = {
   [key: string]: Tensor
@@ -33,4 +34,8 @@ export interface TensorInfo {
   name: string;
   shape?: number[];
   dtype: DataType;
+}
+
+export interface Optimizer {
+  optimize(graph: Graph): Graph;
 }

--- a/src/executor/frozen_model.ts
+++ b/src/executor/frozen_model.ts
@@ -108,8 +108,8 @@ export class FrozenModel implements tfc.InferenceModel {
     const weightMap =
         tfc.io.decodeWeights(artifacts.weightData, artifacts.weightSpecs);
     this.executor = new GraphExecutor(
-        OperationMapper.Instance.transformGraph(graph), this.optimizers);
-    this.executor.weightMap = this.convertTensorMapToTensorsMap(weightMap);
+        OperationMapper.Instance.transformGraph(graph),
+        this.convertTensorMapToTensorsMap(weightMap), this.optimizers);
     return true;
   }
 

--- a/src/executor/frozen_model.ts
+++ b/src/executor/frozen_model.ts
@@ -283,6 +283,8 @@ export class FrozenModel implements tfc.InferenceModel {
  * scripts/convert.py script.
  * @param requestOption options for Request, which allows to send credentials
  * and custom headers.
+ * @param optimizers optional list of optimizer instances, for example
+ * DeviceAllocationOptimizer.
  */
 /** @doc {heading: 'Models', subheading: 'Loading'} */
 export async function loadFrozenModel(

--- a/src/executor/graph_executor.ts
+++ b/src/executor/graph_executor.ts
@@ -25,7 +25,6 @@ import {executeOp} from '../operations/operation_executor';
 import {Graph, Node} from '../operations/types';
 
 import {ExecutionContext, ExecutionContextInfo} from './execution_context';
-import {DeviceAllocationOptimizer} from './optimizers/device_allocation_optimizer';
 
 interface NodeWithContexts {
   contexts: ExecutionContextInfo[];
@@ -88,7 +87,7 @@ export class GraphExecutor {
     this._outputs = graph.outputs;
     this.weightMap = weightMap;
     this.graph =
-        (this.optimizers || [new DeviceAllocationOptimizer()])
+        (this.optimizers || [])
             .reduce(
                 (graph, optimizer) => graph = optimizer.optimize(graph), graph);
     this.compile();

--- a/src/executor/graph_executor.ts
+++ b/src/executor/graph_executor.ts
@@ -18,7 +18,7 @@
 import {DataType, Tensor, tidy, util} from '@tensorflow/tfjs-core';
 
 // tslint:disable-next-line:max-line-length
-import {NamedTensorMap, NamedTensorsMap, TensorArrayMap, TensorInfo} from '../data/types';
+import {NamedTensorMap, NamedTensorsMap, Optimizer, TensorArrayMap, TensorInfo} from '../data/types';
 // tslint:disable-next-line:max-line-length
 import {getNodeNameAndIndex, getParamValue, getTensor} from '../operations/executors/utils';
 import {executeOp} from '../operations/operation_executor';
@@ -80,9 +80,16 @@ export class GraphExecutor {
     return this.outputs.map(node => node.name);
   }
 
-  constructor(private graph: Graph) {
+  constructor(
+      private graph: Graph, weightMap: NamedTensorsMap,
+      private optimizers?: Optimizer[]) {
     this.placeholders = graph.placeholders;
     this._outputs = graph.outputs;
+    this.weightMap = weightMap;
+    this.graph =
+        (this.optimizers || [])
+            .reduce(
+                (graph, optimizer) => graph = optimizer.optimize(graph), graph);
     this.compile();
   }
 

--- a/src/executor/graph_executor.ts
+++ b/src/executor/graph_executor.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  * =============================================================================
  */
-
-import {DataType, Tensor, tidy, util} from '@tensorflow/tfjs-core';
+// tslint:disable-next-line:max-line-length
+import {DataType, getBackend, setBackend, Tensor, tidy, util} from '@tensorflow/tfjs-core';
 
 // tslint:disable-next-line:max-line-length
 import {NamedTensorMap, NamedTensorsMap, Optimizer, TensorArrayMap, TensorInfo} from '../data/types';
@@ -168,8 +168,15 @@ export class GraphExecutor {
       for (let i = 0; i < compiledNodes.length; i++) {
         const node = compiledNodes[i];
         if (!tensorMap[node.name]) {
+          const backend = getBackend();
+          if (node.backend) {
+            setBackend(node.backend);
+          }
           tensorMap[node.name] =
               executeOp(node, tensorMap, context) as Tensor[];
+          if (node.backend) {
+            setBackend(backend);
+          }
         }
         // stop the execution if all outputs are found.
         if (outputNames.every(name => !!tensorMap[name])) {
@@ -264,7 +271,16 @@ export class GraphExecutor {
 
       // only process nodes that are not provided as input nodes.
       if (inputNodes.indexOf(item.node) === -1) {
+        const backend = getBackend();
+        if (item.node.backend) {
+          setBackend(item.node.backend);
+        }
+
         const tensors = executeOp(item.node, tensorMap, context);
+        if (item.node.backend) {
+          setBackend(backend);
+        }
+
         if (!nodeName) {
           [nodeName] = getNodeNameAndIndex(item.node.name, context);
         }

--- a/src/executor/graph_executor_test.ts
+++ b/src/executor/graph_executor_test.ts
@@ -86,8 +86,8 @@ describe('GraphExecutor', () => {
     inputNode.children.push(intermediateNode);
     constNode.children.push(intermediateNode, outputNode);
     intermediateNode.children.push(outputNode);
-    executor = new GraphExecutor(graph, {'const': [constTensor]});
     constTensor = tfc.scalar(2.0);
+    executor = new GraphExecutor(graph, {'const': [constTensor]});
   });
   afterEach(() => {});
 

--- a/src/executor/graph_executor_test.ts
+++ b/src/executor/graph_executor_test.ts
@@ -86,9 +86,8 @@ describe('GraphExecutor', () => {
     inputNode.children.push(intermediateNode);
     constNode.children.push(intermediateNode, outputNode);
     intermediateNode.children.push(outputNode);
-    executor = new GraphExecutor(graph);
+    executor = new GraphExecutor(graph, {'const': [constTensor]});
     constTensor = tfc.scalar(2.0);
-    executor.weightMap = {'const': [constTensor]};
   });
   afterEach(() => {});
 
@@ -285,8 +284,8 @@ describe('GraphExecutor', () => {
             placeholders: [inputNode]
           };
 
-          executor = new GraphExecutor(graphWithControlFlow);
-          executor.weightMap = {const : [constTensor]};
+          executor =
+              new GraphExecutor(graphWithControlFlow, {'const': [constTensor]});
         });
 
         it('should execute control flow graph', (done) => {

--- a/src/executor/optimizers/device_allocation_optimizer.ts
+++ b/src/executor/optimizers/device_allocation_optimizer.ts
@@ -30,7 +30,8 @@ const CPU_OPS = new Set(['rank', 'shape', 'size', 'loopCond']);
  *  4. User can specify the allocation for the input nodes.
  */
 export class DeviceAllocationOptimizer implements Optimizer {
-  constructor(private inputBackend: Backends = 'webgl') {}
+  constructor(private inputBackend: Backends = 'webgl', private debug = false) {
+  }
 
   /**
    * device allocation of the nodes in the input graph.
@@ -80,10 +81,11 @@ export class DeviceAllocationOptimizer implements Optimizer {
         }
       });
     }
-
-    console.log('gpu nodes =', gpuCount);
-    console.log('cpu nodes =', cpuCount);
-    console.log('non-constant cpu nodes =', cpuCount - graph.weights.length);
+    if (this.debug) {
+      console.log('gpu nodes =', gpuCount);
+      console.log('cpu nodes =', cpuCount);
+      console.log('non-constant cpu nodes =', cpuCount - graph.weights.length);
+    }
     return graph;
   }
 }

--- a/src/executor/optimizers/device_allocation_optimizer.ts
+++ b/src/executor/optimizers/device_allocation_optimizer.ts
@@ -17,40 +17,56 @@
 
 import {Optimizer} from '../../data/types';
 import {getNodeNameAndIndex} from '../../operations/executors/utils';
-import {Graph} from '../../operations/types';
+import {Backends, Graph} from '../../operations/types';
 
-const CPU_OPS = new Set(['const', 'rank', 'shape', 'size']);
+const CPU_OPS = new Set(['rank', 'shape', 'size', 'loopCond']);
 
 export class DeviceAllocationOptimizer implements Optimizer {
+  constructor(private inputBackend: Backends = 'webgl') {}
   public optimize(graph: Graph): Graph {
     const inputs = graph.placeholders;
 
     const stack = [...inputs, ...graph.weights];
     const visited: {[key: string]: boolean} = {};
+    let cpuCount = 0;
+    let gpuCount = 0;
     while (stack.length > 0) {
       const node = stack.pop();
       visited[node.name] = true;
 
-      if (node.op === 'placeholder') {
-        node.backend = 'webgl';
-      } else if (CPU_OPS.has(node.op)) {
+      if (node.inputs.every(input => input.backend === 'cpu')) {
         node.backend = 'cpu';
+        cpuCount += 1;
+      } else {
+        node.backend = 'webgl';
+        gpuCount += 1;
       }
 
-      if (node.inputs.some(
-              input => !!input.backend && input.backend === 'webgl')) {
-        node.backend = 'webgl';
+      if (node.op === 'placeholder') {
+        node.backend = this.inputBackend;
+      } else if (CPU_OPS.has(node.op)) {
+        node.backend = 'cpu';
+        cpuCount += 1;
       }
 
       node.children.forEach((childNode) => {
-        if (!visited[childNode.name] && childNode.inputNames.every(name => {
+        if (!visited[childNode.name] &&
+            (childNode.op === 'merge' && childNode.inputNames.some(name => {
               const [nodeName, ] = getNodeNameAndIndex(name);
               return visited[nodeName];
-            })) {
+            }) ||
+             childNode.inputNames.every(name => {
+               const [nodeName, ] = getNodeNameAndIndex(name);
+               return visited[nodeName];
+             }))) {
           stack.push(childNode);
         }
       });
     }
+
+    console.log('gpu nodes =', gpuCount);
+    console.log('cpu nodes =', cpuCount);
+    console.log('non-constant cpu nodes =', cpuCount - graph.weights.length);
     return graph;
   }
 }

--- a/src/executor/optimizers/device_allocation_optimizer.ts
+++ b/src/executor/optimizers/device_allocation_optimizer.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Optimizer} from '../../data/types';
+import {getNodeNameAndIndex} from '../../operations/executors/utils';
+import {Graph} from '../../operations/types';
+
+const CPU_OPS = new Set(['const', 'rank', 'shape', 'size']);
+
+export class DeviceAllocationOptimizer implements Optimizer {
+  public optimize(graph: Graph): Graph {
+    const inputs = graph.placeholders;
+
+    const stack = [...inputs, ...graph.weights];
+    const visited: {[key: string]: boolean} = {};
+    while (stack.length > 0) {
+      const node = stack.pop();
+      visited[node.name] = true;
+
+      if (node.op === 'placeholder') {
+        node.backend = 'webgl';
+      } else if (CPU_OPS.has(node.op)) {
+        node.backend = 'cpu';
+      }
+
+      if (node.inputs.some(
+              input => !!input.backend && input.backend === 'webgl')) {
+        node.backend = 'webgl';
+      }
+
+      node.children.forEach((childNode) => {
+        if (!visited[childNode.name] && childNode.inputNames.every(name => {
+              const [nodeName, ] = getNodeNameAndIndex(name);
+              return visited[nodeName];
+            })) {
+          stack.push(childNode);
+        }
+      });
+    }
+    return graph;
+  }
+}

--- a/src/executor/optimizers/device_allocation_optimizer.ts
+++ b/src/executor/optimizers/device_allocation_optimizer.ts
@@ -36,19 +36,21 @@ export class DeviceAllocationOptimizer implements Optimizer {
 
       if (node.inputs.every(input => input.backend === 'cpu')) {
         node.backend = 'cpu';
-        cpuCount += 1;
       } else {
         node.backend = 'webgl';
-        gpuCount += 1;
       }
 
       if (node.op === 'placeholder') {
         node.backend = this.inputBackend;
       } else if (CPU_OPS.has(node.op)) {
         node.backend = 'cpu';
-        cpuCount += 1;
       }
 
+      if (node.backend === 'cpu') {
+        cpuCount += 1;
+      } else {
+        gpuCount += 1;
+      }
       node.children.forEach((childNode) => {
         if (!visited[childNode.name] &&
             (childNode.op === 'merge' && childNode.inputNames.some(name => {

--- a/src/executor/optimizers/device_allocation_optimizer_test.ts
+++ b/src/executor/optimizers/device_allocation_optimizer_test.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Graph, Node} from '../../operations/types';
+
+import {DeviceAllocationOptimizer} from './device_allocation_optimizer';
+
+let optimizer: DeviceAllocationOptimizer;
+const EMPTY_GRAPH: Graph = {
+  inputs: [],
+  nodes: {},
+  weights: [],
+  outputs: [],
+  placeholders: [],
+  withControlFlow: false,
+  withDynamicShape: false
+};
+
+const inputNode: Node = {
+  inputNames: [],
+  inputs: [],
+  children: [],
+  name: 'input',
+  op: 'placeholder',
+  category: 'graph',
+  params: {}
+};
+const constNode: Node = {
+  inputNames: [],
+  inputs: [],
+  children: [],
+  name: 'const',
+  op: 'const',
+  category: 'graph',
+  params: {}
+};
+const intermediateNode: Node = {
+  inputNames: ['input', 'const'],
+  inputs: [inputNode, constNode],
+  children: [],
+  name: 'intermediate',
+  op: 'shape',
+  category: 'arithmetic',
+  params: {}
+};
+const outputNode: Node = {
+  inputNames: ['intermediate', 'input'],
+  inputs: [intermediateNode, inputNode],
+  children: [],
+  name: 'output',
+  op: 'add',
+  category: 'arithmetic',
+  params: {}
+};
+const graph: Graph = {
+  inputs: [constNode, inputNode],
+  nodes: {
+    'input': inputNode,
+    'const': constNode,
+    'intermediate': intermediateNode,
+    'output': outputNode
+  },
+  outputs: [outputNode],
+  weights: [constNode],
+  withControlFlow: false,
+  withDynamicShape: false,
+  placeholders: [inputNode]
+};
+inputNode.children.push(intermediateNode);
+constNode.children.push(intermediateNode, outputNode);
+intermediateNode.children.push(outputNode);
+
+describe('DeviceAllocationOptimizer', () => {
+  beforeEach(() => {
+    optimizer = new DeviceAllocationOptimizer();
+  });
+
+  it('should handle empty graph', () => {
+    expect(optimizer.optimize(EMPTY_GRAPH)).toEqual(EMPTY_GRAPH);
+  });
+
+  it('should have the same nodes count', () => {
+    const count = Object.keys(graph.nodes).length;
+    const newNodes = optimizer.optimize(graph).nodes;
+    expect(Object.keys(newNodes).length).toEqual(count);
+  });
+
+  it('should allocate device for each node', () => {
+    const newNodes = optimizer.optimize(graph).nodes;
+    expect(Object.keys(newNodes)
+               .map(key => newNodes[key])
+               .map(node => node.backend)
+               .every(backend => !!backend))
+        .toBeTruthy();
+  });
+
+  it('should allocate input node based on the config', () => {
+    let newNodes = optimizer.optimize(graph).nodes;
+    expect(newNodes[inputNode.name].backend).toEqual('webgl');
+
+    optimizer = new DeviceAllocationOptimizer('cpu');
+    newNodes = optimizer.optimize(graph).nodes;
+    expect(newNodes[inputNode.name].backend).toEqual('cpu');
+  });
+
+  it('should allocate input node based on the config', () => {
+    let newNodes = optimizer.optimize(graph).nodes;
+    expect(newNodes[inputNode.name].backend).toEqual('webgl');
+
+    optimizer = new DeviceAllocationOptimizer('cpu');
+    newNodes = optimizer.optimize(graph).nodes;
+    expect(newNodes[inputNode.name].backend).toEqual('cpu');
+  });
+
+  it('should allocate const node to cpu', () => {
+    const newNodes = optimizer.optimize(graph).nodes;
+    expect(newNodes[constNode.name].backend).toEqual('cpu');
+  });
+
+  it('should allocate shape node to cpu', () => {
+    const newNodes = optimizer.optimize(graph).nodes;
+    expect(newNodes[intermediateNode.name].backend).toEqual('cpu');
+  });
+
+  it('should allocate add node to webgl', () => {
+    const newNodes = optimizer.optimize(graph).nodes;
+    expect(newNodes[outputNode.name].backend).toEqual('webgl');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,6 @@
  * =============================================================================
  */
 export {FrozenModel, loadFrozenModel} from './executor/frozen_model';
+// tslint:disable-next-line:max-line-length
+export {DeviceAllocationOptimizer} from './executor/optimizers/device_allocation_optimizer';
 export {version as version_converter} from './version';

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -20,6 +20,8 @@ export type ParamTypes =
 export type Category = 'arithmetic'|'basic_math'|'control'|'convolution'|
     'dynamic'|'evaluation'|'image'|'creation'|'graph'|'logical'|'matrices'|
     'normalization'|'reduction'|'slice_join'|'transformation';
+export type Backends = 'cpu'|'webgl';
+
 export declare interface ParamMapper {
   tfParamName?: string;
   tfParamNameDeprecated?: string;
@@ -47,6 +49,7 @@ export declare interface Node {
   inputs: Node[];
   params: {[key: string]: ParamValue};
   children: Node[];
+  backend?: Backends;
 }
 
 export declare interface Graph {


### PR DESCRIPTION
This PR also setup frozen model to have a precompile stage, where the graph of the model is optimized.

The DeviceAllocationOptimizer tries to improve the inference performance by minimizing the tensor copying between browser backends (webgl, cpu). It follows the following set of heuristics on where to allocate a particular op. 

  1. If any of the inputs is on webgl the op will be executed on webgl.
  2. If all of the inputs are on cpu the op will be executed on cpu.
  3. Always allocate CPU optimized ops to cpu execution.
  4. User can specify the allocation for the input nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/216)
<!-- Reviewable:end -->
