### PR TITLE
NPM Ignore: Ignore rollup configurations

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -28,3 +28,4 @@ DEVELOPMENT.md
 ISSUE_TEMPLATE.md
 rollup.config.js
 test_results
+rollup.config.google.js


### PR DESCRIPTION
This PR adds `rollup.config.google.js` to npmignore.