### PR TITLE
converting keras only makes model.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ $ tensorflowjs_converter \
 
 ### Web-friendly format
 
-The conversion script above produces 3 types of files:
+The conversion script above produces 4 types of files:
 
 * `tensorflowjs_model.pb` (the dataflow graph)
 * `weights_manifest.json` (weight manifest file)
+* `model.json` (the two above, in a single file)
 * `group1-shard\*of\*` (collection of binary weight files)
 
 For example, here is the MobileNet model converted and served in

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ The conversion script above produces 4 types of files:
 * `model.json` (the two above, in a single file)
 * `group1-shard\*of\*` (collection of binary weight files)
 
+For `keras` input files, the converter generates `model.json` and sharded weight files.
+For other input formats, it generates the other three.
+
 For example, here is the MobileNet model converted and served in
 following location:
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ The conversion script above produces 4 types of files:
 * `model.json` (the two above, in a single file)
 * `group1-shard\*of\*` (collection of binary weight files)
 
-For `keras` input files, the converter generates `model.json` and sharded weight files.
-For other input formats, it generates the other three.
+For `keras` input files, the converter generates `model.json` and `group1-shard\*of\*`.
+For other input formats, it generates the `tensorflowjs_model.pb`, `weights_manifest.json`, and `group1-shard\*of\*`.
 
 For example, here is the MobileNet model converted and served in
 following location:


### PR DESCRIPTION
When converting a keras model, a single file `model.json` file as well as binary weight files are produced. It would be very helpful to state this clearly (since it tripped me up) though my wording in the PR is probably less than ideal.

More details in an issue here: tensorflow/tfjs#780

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/222)
<!-- Reviewable:end -->
