### PR TITLE
move the protobufjs dep to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "tslint": "~5.8.0",
     "tslint-no-circular-imports": "~0.5.0",
     "typescript": "~2.7.2",
-    "yalc": "~1.0.0-pre.21"
+    "yalc": "~1.0.0-pre.21",
+    "@types/long": "~3.0.32",
+    "protobufjs": "~6.8.6"
   },
   "scripts": {
     "build": "tsc && copyfiles -f src/data/compiled_api.* dist/src/data/",
@@ -60,9 +62,5 @@
     "gen-doc": "ts-node ./scripts/gen_doc.ts",
     "gen-google3-proto": "rollup -c rollup.config.google.js",
     "gen-json": "ts-node ./scripts/gen_json.ts"
-  },
-  "dependencies": {
-    "@types/long": "~3.0.32",
-    "protobufjs": "~6.8.6"
   }
 }


### PR DESCRIPTION
The protobuf.js and long typedef are only needed for building not for runtime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/241)
<!-- Reviewable:end -->
