### PR TITLE
Clear all data fields in constant tensors

### DIFF
--- a/python/tensorflowjs/converters/tf_saved_model_conversion.py
+++ b/python/tensorflowjs/converters/tf_saved_model_conversion.py
@@ -36,6 +36,10 @@ import tensorflow_hub as hub
 from tensorflowjs import write_weights
 
 DEFAULT_MODEL_PB_FILENAME = 'tensorflowjs_model.pb'
+CLEARED_TENSOR_FIELDS = (
+    'tensor_content', 'half_val', 'float_val', 'double_val', 'int_val',
+    'string_val', 'scomplex_val', 'int64_val', 'bool_val',
+    'resource_handle_val', 'variant_val', 'uint32_val', 'uint64_val')
 
 
 def get_cluster():
@@ -171,7 +175,8 @@ def extract_weights(graph_def,
       const.input[:] = constInputs[const.name]
 
       # Remove the binary array from tensor and save it to the external file.
-      const.attr["value"].tensor.ClearField('tensor_content')
+      for field_name in CLEARED_TENSOR_FIELDS:
+        const.attr["value"].tensor.ClearField(field_name)
 
   write_weights.write_weights(
       [const_manifest], path, quantization_dtype=quantization_dtype)


### PR DESCRIPTION
The tensor proto defines various data fields, and the real content
may be stored in them instead of `tensor_content`. For example,

```
tensorflowjs_converter --input_format=tf_hub 'https://tfhub.dev/google/progan-128/1' /tmp/progan
```

generates `tensorflowjs_model.pb` with unstripped weights and thus the model bundle
is twice as large as it should be. The reason is that some tensors carry data
in `float_val` instead of `tensor_content`.

Signed-off-by: Vadim Markovtsev <vadim@sourced.tech>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/242)
<!-- Reviewable:end -->
