### PR TITLE
Support converting tf.keras SavedModel format into TF.js format

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A 2-step process to import your model:
 1. A python pip package to convert a TensorFlow SavedModel/Frozen Model/Session Bundle to a web friendly format. If you already have a converted model, or are using an already hosted model (e.g. MobileNet), skip this step.
 2. [Javascript API](./src/executor/tf_model.ts), for loading and running inference.
 
-## Step 1: Converting a [SavedModel](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/saved_model/README.md), [Keras h5](https://keras.io/getting-started/faq/#how-can-i-save-a-keras-model), [Session Bundle](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/session_bundle/README.md), [Frozen Model](https://www.tensorflow.org/mobile/prepare_models#how_do_you_get_a_model_you_can_use_on_mobile) or [TensorFlow Hub module](https://www.tensorflow.org/hub/) to a web-friendly format
+## Step 1: Converting a [SavedModel](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/saved_model/README.md), [Keras h5](https://keras.io/getting-started/faq/#how-can-i-save-a-keras-model), [tf.keras SavedModel](https://www.tensorflow.org/api_docs/python/tf/contrib/saved_model/save_keras_model), [Session Bundle](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/session_bundle/README.md), [Frozen Model](https://www.tensorflow.org/mobile/prepare_models#how_do_you_get_a_model_you_can_use_on_mobile) or [TensorFlow Hub module](https://www.tensorflow.org/hub/) to a web-friendly format
 
 1. Install the TensorFlow.js pip package:
 

--- a/README.md
+++ b/README.md
@@ -80,10 +80,9 @@ tf.keras SavedModel model example:
 ```bash
 $ tensorflowjs_converter \
     --input_format=keras_saved_model \
-    /tmp/my_keras_model.h5 \
+    /tmp/my_tf_keras_saved_model/1542211770 \
     /tmp/my_tfjs_model
 ```
-
 
 |Positional Arguments | Description |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ $ tensorflowjs_converter \
     /tmp/my_tfjs_model
 ```
 
+tf.keras SavedModel model example:
+
+```bash
+$ tensorflowjs_converter \
+    --input_format=keras_saved_model \
+    /tmp/my_keras_model.h5 \
+    /tmp/my_tfjs_model
+```
+
 
 |Positional Arguments | Description |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ $ tensorflowjs_converter \
     /tmp/my_tfjs_model
 ```
 
+Note that the input path used above is a subfolder that has a Unix epoch
+time (1542211770) and is generated automatically by tensorflow when it
+saved a tf.keras model in the SavedModel format.
+
 |Positional Arguments | Description |
 |---|---|
 |`input_path`  | Full path of the saved model directory, session bundle directory, frozen model file or TensorFlow Hub module handle or path.|

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,5 +2,5 @@ h5py==2.8.0
 keras==2.2.2
 numpy==1.15.1
 six==1.11.0
-tensorflow==1.11.0
+tensorflow==1.12.0
 tensorflow_hub==0.1.1

--- a/python/tensorflowjs/converters/BUILD
+++ b/python/tensorflowjs/converters/BUILD
@@ -90,5 +90,6 @@ py_test(
         ":converter",
         "//tensorflowjs:expect_keras_installed",
         "//tensorflowjs:expect_tensorflow_installed",
+        "//tensorflowjs:read_weights",
     ],
 )

--- a/python/tensorflowjs/converters/BUILD
+++ b/python/tensorflowjs/converters/BUILD
@@ -88,7 +88,6 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":converter",
-        ":keras_tfjs_loader",
         "//tensorflowjs:expect_keras_installed",
         "//tensorflowjs:expect_tensorflow_installed",
     ],

--- a/python/tensorflowjs/converters/BUILD
+++ b/python/tensorflowjs/converters/BUILD
@@ -90,6 +90,7 @@ py_test(
         ":converter",
         ":keras_tfjs_loader",
         "//tensorflowjs:expect_keras_installed",
+        "//tensorflowjs:expect_numpy_installed",
         "//tensorflowjs:expect_tensorflow_installed",
         "//tensorflowjs:read_weights",
     ],

--- a/python/tensorflowjs/converters/BUILD
+++ b/python/tensorflowjs/converters/BUILD
@@ -92,6 +92,5 @@ py_test(
         "//tensorflowjs:expect_keras_installed",
         "//tensorflowjs:expect_numpy_installed",
         "//tensorflowjs:expect_tensorflow_installed",
-        "//tensorflowjs:read_weights",
     ],
 )

--- a/python/tensorflowjs/converters/BUILD
+++ b/python/tensorflowjs/converters/BUILD
@@ -88,6 +88,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":converter",
+        ":keras_tfjs_loader",
         "//tensorflowjs:expect_keras_installed",
         "//tensorflowjs:expect_tensorflow_installed",
     ],

--- a/python/tensorflowjs/converters/BUILD
+++ b/python/tensorflowjs/converters/BUILD
@@ -88,6 +88,7 @@ py_test(
     srcs_version = "PY2AND3",
     deps = [
         ":converter",
+        ":keras_tfjs_loader",
         "//tensorflowjs:expect_keras_installed",
         "//tensorflowjs:expect_tensorflow_installed",
         "//tensorflowjs:read_weights",

--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -64,6 +64,13 @@ def dispatch_keras_h5_to_tensorflowjs_conversion(
         will be `None`.
       groups: an array of weight_groups as defined in tfjs weights_writer.
   """
+  if not os.path.exists(h5_path):
+    raise ValueError('Nonexistent path to HDF5 file: %s' % h5_path)
+  elif os.path.isdir(h5_path):
+    raise ValueError(
+        'Expected path to point to an HDF5 file, but it points to a '
+        'directory: %s' % h5_path)
+
   converter = keras_h5_conversion.HDF5Converter()
 
   h5_file = h5py.File(h5_path)
@@ -173,7 +180,9 @@ def main():
       '    `keras.model.save_model()` method).\n'
       '  - A weights-only HDF5 (e.g., generated with Keras Model\'s '
       '    `save_weights()` method). \n'
-      'For "keras_saved_model" TODO(cais): Description DO NOT SUBMIT'
+      'For "keras_saved_model", the input_path must point to a subfolder '
+      'under the saved model folder. The subfolder is usually named as a '
+      'Unix epoch time (e.g., 1542212752)\n'
       'For "tf" formats, a SavedModel, frozen model, session bundle model, '
       ' or TF-Hub module is expected.')
   parser.add_argument(

--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -97,6 +97,28 @@ def dispatch_keras_h5_to_tensorflowjs_conversion(
 def dispatch_keras_saved_model_to_tensorflowjs_conversion(
     keras_saved_model_path, output_dir, quantization_dtype=None,
     split_weights_by_layer=False):
+  """Converts a tf.keras model saved in the TensorFlow SavedModel format
+
+  into to TensorFlow.js format.
+
+  Note that the SavedModel format exists in tf.keras, but not in
+  keras-team/keras.
+
+  Args:
+    keras_saved_model_path: path to a folder in which the
+      assets/saved_model.json can be found. This is usually a subfolder
+      that is under the folder passed to
+      `tf.contrib.saved_model.save_keras_model()` and has a Unix epoch time
+      as its name (e.g., 1542212752).
+    output_dir: Output directory to which the TensorFlow.js-format model JSON
+      file and weights files will be written. If the directory does not exist,
+      it will be created.
+    quantization_dtype: The quantized data type to store the weights in
+      (Default: `None`).
+    split_weights_by_layer: Whether to split the weights into separate weight
+      groups (corresponding to separate binary weight files) layer by layer
+      (Default: `False`).
+  """
   with tf.Graph().as_default(), tf.Session():
     model = tf.contrib.saved_model.load_keras_model(keras_saved_model_path)
 

--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -90,21 +90,22 @@ def dispatch_keras_h5_to_tensorflowjs_conversion(
 def dispatch_keras_saved_model_to_tensorflowjs_conversion(
     keras_saved_model_path, output_dir, quantization_dtype=None,
     split_weights_by_layer=False):
-  model = tf.contrib.saved_model.load_keras_model(keras_saved_model_path)
+  with tf.Graph().as_default(), tf.Session():
+    model = tf.contrib.saved_model.load_keras_model(keras_saved_model_path)
 
-  # Save model temporarily in HDF5 format.
-  temp_h5_path = tempfile.mktemp(suffix='.h5')
-  model.save(temp_h5_path)
-  assert os.path.isfile(temp_h5_path)
+    # Save model temporarily in HDF5 format.
+    temp_h5_path = tempfile.mktemp(suffix='.h5')
+    model.save(temp_h5_path)
+    assert os.path.isfile(temp_h5_path)
 
-  dispatch_keras_h5_to_tensorflowjs_conversion(
-      temp_h5_path,
-      output_dir,
-      quantization_dtype=quantization_dtype,
-      split_weights_by_layer=split_weights_by_layer)
+    dispatch_keras_h5_to_tensorflowjs_conversion(
+        temp_h5_path,
+        output_dir,
+        quantization_dtype=quantization_dtype,
+        split_weights_by_layer=split_weights_by_layer)
 
-  # Delete temporary .h5 file.
-  os.remove(temp_h5_path)
+    # Delete temporary .h5 file.
+    os.remove(temp_h5_path)
 
 
 def dispatch_tensorflowjs_to_keras_h5_conversion(config_json_path, h5_path):

--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -97,9 +97,7 @@ def dispatch_keras_h5_to_tensorflowjs_conversion(
 def dispatch_keras_saved_model_to_tensorflowjs_conversion(
     keras_saved_model_path, output_dir, quantization_dtype=None,
     split_weights_by_layer=False):
-  """Converts a tf.keras model saved in the TensorFlow SavedModel format
-
-  into to TensorFlow.js format.
+  """Converts tf.keras model saved in the SavedModel format to tfjs format.
 
   Note that the SavedModel format exists in tf.keras, but not in
   keras-team/keras.

--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -203,8 +203,10 @@ def main():
       '  - A weights-only HDF5 (e.g., generated with Keras Model\'s '
       '    `save_weights()` method). \n'
       'For "keras_saved_model", the input_path must point to a subfolder '
-      'under the saved model folder. The subfolder is usually named as a '
-      'Unix epoch time (e.g., 1542212752)\n'
+      'under the saved model folder that is passed as the argument '
+      'to tf.contrib.save_model.save_keras_model(). '
+      'The subfolder is usually named as a '
+      'Unix epoch time (e.g., 1542212752) as its name.\n'
       'For "tf" formats, a SavedModel, frozen model, session bundle model, '
       ' or TF-Hub module is expected.')
   parser.add_argument(

--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -92,7 +92,7 @@ def dispatch_keras_saved_model_to_tensorflowjs_conversion(
     split_weights_by_layer=False):
   model = tf.contrib.saved_model.load_keras_model(keras_saved_model_path)
 
-  # Save model temporarily in H5 format.
+  # Save model temporarily in HDF5 format.
   temp_h5_path = tempfile.mktemp(suffix='.h5')
   model.save(temp_h5_path)
   assert os.path.isfile(temp_h5_path)
@@ -102,6 +102,8 @@ def dispatch_keras_saved_model_to_tensorflowjs_conversion(
       output_dir,
       quantization_dtype=quantization_dtype,
       split_weights_by_layer=split_weights_by_layer)
+
+  # Delete temporary .h5 file.
   os.remove(temp_h5_path)
 
 

--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -203,8 +203,9 @@ def main():
       'For "keras_saved_model", the input_path must point to a subfolder '
       'under the saved model folder that is passed as the argument '
       'to tf.contrib.save_model.save_keras_model(). '
-      'The subfolder is usually named as a '
-      'Unix epoch time (e.g., 1542212752) as its name.\n'
+      'The subfolder is generated automatically by tensorflow when '
+      'saving tf.keras model in the SavedModel format. It is usually named '
+      'as a Unix epoch time (e.g., 1542212752).\n'
       'For "tf" formats, a SavedModel, frozen model, session bundle model, '
       ' or TF-Hub module is expected.')
   parser.add_argument(

--- a/python/tensorflowjs/converters/converter_test.py
+++ b/python/tensorflowjs/converters/converter_test.py
@@ -315,8 +315,6 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       converter.dispatch_keras_saved_model_to_tensorflowjs_conversion(
           save_result_dir, tfjs_output_dir)
 
-      print(glob.glob(os.path.join(tfjs_output_dir, '*')))
-
       # Check the content of the output directory.
       output_json = json.load(
           open(os.path.join(tfjs_output_dir, 'model.json'), 'rt'))
@@ -328,7 +326,6 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       # Verify the size of the weight file.
       weight_path = glob.glob(os.path.join(tfjs_output_dir, 'group*-*'))[0]
       weight_file_bytes = os.path.getsize(weight_path)
-      print('weight_file_bytes = %d' % weight_file_bytes)  # DEBUG
       model_weight_bytes = sum(w.size * 4 for w in model.get_weights())
       self.assertEqual(weight_file_bytes, model_weight_bytes)
 
@@ -343,8 +340,6 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       converter.dispatch_keras_saved_model_to_tensorflowjs_conversion(
           save_result_dir, tfjs_output_dir)
 
-      print(glob.glob(os.path.join(tfjs_output_dir, '*')))
-
       # Check the content of the output directory.
       output_json = json.load(
           open(os.path.join(tfjs_output_dir, 'model.json'), 'rt'))
@@ -356,7 +351,6 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       # Verify the size of the weight file.
       weight_path = glob.glob(os.path.join(tfjs_output_dir, 'group*-*'))[0]
       weight_file_bytes = os.path.getsize(weight_path)
-      print('weight_file_bytes = %d' % weight_file_bytes)  # DEBUG
       model_weight_bytes = sum(w.size * 4 for w in model.get_weights())
       self.assertEqual(weight_file_bytes, model_weight_bytes)
 
@@ -371,8 +365,6 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       converter.dispatch_keras_saved_model_to_tensorflowjs_conversion(
           save_result_dir, tfjs_output_dir)
 
-      print(glob.glob(os.path.join(tfjs_output_dir, '*')))
-
       # Check the content of the output directory.
       output_json = json.load(
           open(os.path.join(tfjs_output_dir, 'model.json'), 'rt'))
@@ -384,7 +376,6 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       # Verify the size of the weight file.
       weight_path = glob.glob(os.path.join(tfjs_output_dir, 'group*-*'))[0]
       weight_file_bytes = os.path.getsize(weight_path)
-      print('weight_file_bytes = %d' % weight_file_bytes)  # DEBUG
       model_weight_bytes = sum(w.size * 4 for w in model.get_weights())
       self.assertEqual(weight_file_bytes, model_weight_bytes)
 

--- a/python/tensorflowjs/converters/converter_test.py
+++ b/python/tensorflowjs/converters/converter_test.py
@@ -341,8 +341,6 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
   def testWrongConverterRaisesCorrectErrorMessage(self):
     with tf.Graph().as_default(), tf.Session():
       model = self._createSimpleSequentialModel()
-      old_model_json = json.loads(model.to_json())
-      old_weights = model.get_weights()
       tf.contrib.saved_model.save_keras_model(model, self._tmp_dir)
       save_result_dir = glob.glob(os.path.join(self._tmp_dir, '*'))[0]
 
@@ -421,8 +419,6 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
   def testConvertTfKerasSequentialSavedAsSavedModelWithQuantization(self):
     with tf.Graph().as_default(), tf.Session():
       model = self._createSimpleSequentialModel()
-      old_model_json = json.loads(model.to_json())
-      old_weights = model.get_weights()
       tf.contrib.saved_model.save_keras_model(model, self._tmp_dir)
       save_result_dir = glob.glob(os.path.join(self._tmp_dir, '*'))[0]
 

--- a/python/tensorflowjs/converters/converter_test.py
+++ b/python/tensorflowjs/converters/converter_test.py
@@ -347,7 +347,10 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       # Convert the tf.keras SavedModel to tfjs format.
       tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
       # Use wrong dispatcher.
-      with self.assertRaisesRegexp(ValueError):
+      with self.assertRaisesRegexp(  # pylint: disable=deprecated-method
+          ValueError,
+          r'Expected path to point to an HDF5 file, but it points to a '
+          r'directory'):
         converter.dispatch_keras_h5_to_tensorflowjs_conversion(
             save_result_dir, tfjs_output_dir)
 

--- a/python/tensorflowjs/converters/converter_test.py
+++ b/python/tensorflowjs/converters/converter_test.py
@@ -28,7 +28,9 @@ import unittest
 import keras
 import tensorflow as tf
 
+from tensorflowjs import read_weights
 from tensorflowjs.converters import converter
+
 
 # TODO(adarob): Add tests for quantization option.
 
@@ -328,6 +330,11 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       weight_file_bytes = os.path.getsize(weight_path)
       model_weight_bytes = sum(w.size * 4 for w in model.get_weights())
       self.assertEqual(weight_file_bytes, model_weight_bytes)
+
+      # Verify the content of the weight file.
+      weights = read_weights.read_weights(
+          output_json['weightsManifest'], tfjs_output_dir)
+      print(weights)
 
   def testConvertTfKerasNestedSequentialSavedAsSavedModel(self):
     with tf.Graph().as_default(), tf.Session():

--- a/python/tensorflowjs/converters/converter_test.py
+++ b/python/tensorflowjs/converters/converter_test.py
@@ -347,10 +347,7 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       # Convert the tf.keras SavedModel to tfjs format.
       tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
       # Use wrong dispatcher.
-      with self.assertRaisesRegexp(
-          ValueError,
-          r'Expected path to point to an HDF5 file, '
-          r'but it points to a directory'):
+      with self.assertRaisesRegexp(ValueError):
         converter.dispatch_keras_h5_to_tensorflowjs_conversion(
             save_result_dir, tfjs_output_dir)
 

--- a/python/tensorflowjs/converters/converter_test.py
+++ b/python/tensorflowjs/converters/converter_test.py
@@ -29,7 +29,6 @@ import keras
 import tensorflow as tf
 
 from tensorflowjs.converters import converter
-from tensorflowjs.converters import keras_tfjs_loader
 
 # TODO(adarob): Add tests for quantization option.
 
@@ -381,7 +380,7 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
           model_json['config'],
           output_json['modelTopology']['model_config']['config'])
       self.assertIsInstance(output_json['weightsManifest'], list)
-      
+
       # Verify the size of the weight file.
       weight_path = glob.glob(os.path.join(tfjs_output_dir, 'group*-*'))[0]
       weight_file_bytes = os.path.getsize(weight_path)

--- a/python/tensorflowjs/converters/keras_h5_conversion.py
+++ b/python/tensorflowjs/converters/keras_h5_conversion.py
@@ -250,8 +250,6 @@ class HDF5Converter(object):
     weights_manifest = write_weights.write_weights(
         weights, output_dir, write_manifest=False,
         quantization_dtype=quantization_dtype)
-    if not isinstance(weights_manifest, list):
-      weights_manifest = json.loads(weights_manifest)
     assert isinstance(weights_manifest, list)
     model_json[ARTIFACT_WEIGHTS_MANIFEST_KEY] = weights_manifest
 

--- a/python/tensorflowjs/converters/keras_tfjs_loader.py
+++ b/python/tensorflowjs/converters/keras_tfjs_loader.py
@@ -54,6 +54,7 @@ def _deserialize_keras_model(model_topology_json,
     model_topology_json = json.load(model_topology_json)
   is_tf_keras = ('keras_version' in model_topology_json and
                  model_topology_json['keras_version'].endswith('-tf'))
+  print('is_tf_keras = %s' % is_tf_keras)  # DEBUG
 
   if 'model_config' in model_topology_json:
     model_topology_json = model_topology_json['model_config']
@@ -63,6 +64,8 @@ def _deserialize_keras_model(model_topology_json,
       model = tf.keras.models.model_from_json(json.dumps(model_topology_json))
     else:
       model = keras.models.model_from_json(json.dumps(model_topology_json))
+    print('Loaded:')  # DEBUG
+    model.summary()  # DEBUG
 
   if weight_entries:
     weights_dict = dict()
@@ -205,6 +208,7 @@ def load_keras_model(config_json_path,
           'Weights path prefix is not an existing directory: %s' %
           weights_path_prefix)
     if weights_path_prefix:
+      print('weights_manifest = %s' % weights_manifest)  # DEBUG
       weight_entries = read_weights.read_weights(weights_manifest,
                                                  weights_path_prefix,
                                                  flatten=True)

--- a/python/tensorflowjs/converters/keras_tfjs_loader.py
+++ b/python/tensorflowjs/converters/keras_tfjs_loader.py
@@ -54,7 +54,6 @@ def _deserialize_keras_model(model_topology_json,
     model_topology_json = json.load(model_topology_json)
   is_tf_keras = ('keras_version' in model_topology_json and
                  model_topology_json['keras_version'].endswith('-tf'))
-  print('is_tf_keras = %s' % is_tf_keras)  # DEBUG
 
   if 'model_config' in model_topology_json:
     model_topology_json = model_topology_json['model_config']
@@ -64,8 +63,6 @@ def _deserialize_keras_model(model_topology_json,
       model = tf.keras.models.model_from_json(json.dumps(model_topology_json))
     else:
       model = keras.models.model_from_json(json.dumps(model_topology_json))
-    print('Loaded:')  # DEBUG
-    model.summary()  # DEBUG
 
   if weight_entries:
     weights_dict = dict()
@@ -208,7 +205,6 @@ def load_keras_model(config_json_path,
           'Weights path prefix is not an existing directory: %s' %
           weights_path_prefix)
     if weights_path_prefix:
-      print('weights_manifest = %s' % weights_manifest)  # DEBUG
       weight_entries = read_weights.read_weights(weights_manifest,
                                                  weights_path_prefix,
                                                  flatten=True)

--- a/python/tensorflowjs/read_weights_test.py
+++ b/python/tensorflowjs/read_weights_test.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import json
 import os
 import shutil
 import unittest

--- a/python/tensorflowjs/read_weights_test.py
+++ b/python/tensorflowjs/read_weights_test.py
@@ -48,8 +48,7 @@ class ReadWeightsTest(unittest.TestCase):
         }]
     ]
 
-    manifest_json = write_weights.write_weights(groups, self._tmp_dir)
-    manifest = json.loads(manifest_json)
+    manifest = write_weights.write_weights(groups, self._tmp_dir)
 
     # Read the weights using `read_weights`.
     read_output = read_weights.read_weights(manifest, self._tmp_dir)
@@ -67,8 +66,7 @@ class ReadWeightsTest(unittest.TestCase):
         }]
     ]
 
-    manifest_json = write_weights.write_weights(groups, self._tmp_dir)
-    manifest = json.loads(manifest_json)
+    manifest = write_weights.write_weights(groups, self._tmp_dir)
 
     # Read the weights using `read_weights`.
     read_output = read_weights.read_weights(
@@ -88,8 +86,7 @@ class ReadWeightsTest(unittest.TestCase):
         }]
     ]
 
-    manifest_json = write_weights.write_weights(groups, self._tmp_dir)
-    manifest = json.loads(manifest_json)
+    manifest = write_weights.write_weights(groups, self._tmp_dir)
 
     # Read the weights using `read_weights`.
     read_output = read_weights.read_weights(
@@ -112,8 +109,7 @@ class ReadWeightsTest(unittest.TestCase):
         }]
     ]
 
-    manifest_json = write_weights.write_weights(groups, self._tmp_dir)
-    manifest = json.loads(manifest_json)
+    manifest = write_weights.write_weights(groups, self._tmp_dir)
 
     # Read the weights using `read_weights`.
     read_output = read_weights.read_weights(
@@ -132,8 +128,7 @@ class ReadWeightsTest(unittest.TestCase):
         }]
     ]
 
-    manifest_json = write_weights.write_weights(groups, self._tmp_dir)
-    manifest = json.loads(manifest_json)
+    manifest = write_weights.write_weights(groups, self._tmp_dir)
 
     # Read the weights using `read_weights`.
     read_output = read_weights.read_weights(manifest, self._tmp_dir)
@@ -165,9 +160,8 @@ class ReadWeightsTest(unittest.TestCase):
         }]
     ]
 
-    manifest_json = write_weights.write_weights(
+    manifest = write_weights.write_weights(
         groups, self._tmp_dir, quantization_dtype=np.uint8)
-    manifest = json.loads(manifest_json)
 
     # Read the weights using `read_weights`.
     read_output = read_weights.read_weights(manifest, self._tmp_dir)

--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -63,7 +63,7 @@ def write_weights(
       quantization_dtype: An optional numpy dtype to quantize weights to for
         compression. Only np.uint8 and np.uint16 are supported.
     Returns:
-      The weights manifest JSON string.
+      The weights manifest JSON dict.
 
       An example manifest with 2 groups, 2 weights, and each weight sharded
       into 2:
@@ -124,14 +124,12 @@ def write_weights(
     }
     manifest.append(manifest_entry)
 
-  manifest_json = json.dumps(manifest)
-
   if write_manifest:
     manifest_path = os.path.join(write_dir, 'weights_manifest.json')
     with open(manifest_path, 'wb') as f:
-      f.write(manifest_json.encode())
+      f.write(json.dumps(manifest).encode())
 
-  return manifest_json
+  return manifest
 
 def _quantize_entry(entry, quantization_dtype):
   """Quantizes the weights in the entry, returning a new entry.

--- a/python/tensorflowjs/write_weights_test.py
+++ b/python/tensorflowjs/write_weights_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-import json
 import os
 import shutil
 import unittest

--- a/python/tensorflowjs/write_weights_test.py
+++ b/python/tensorflowjs/write_weights_test.py
@@ -43,9 +43,8 @@ class TestWriteWeights(unittest.TestCase):
         }]
     ]
 
-    manifest_json = write_weights.write_weights(
+    manifest = write_weights.write_weights(
         groups, TMP_DIR, shard_size_bytes=4 * 4)
-    manifest = json.loads(manifest_json)
 
     self.assertTrue(
         os.path.isfile(os.path.join(TMP_DIR, 'weights_manifest.json')),
@@ -74,9 +73,8 @@ class TestWriteWeights(unittest.TestCase):
         }]
     ]
 
-    manifest_json = write_weights.write_weights(
+    manifest = write_weights.write_weights(
         groups, TMP_DIR, shard_size_bytes=4 * 4)
-    manifest = json.loads(manifest_json)
 
     self.assertTrue(
         os.path.isfile(os.path.join(TMP_DIR, 'weights_manifest.json')),
@@ -107,9 +105,8 @@ class TestWriteWeights(unittest.TestCase):
     ]
     # Shard size is smaller than the size of the array so it gets split between
     # multiple files.
-    manifest_json = write_weights.write_weights(
+    manifest = write_weights.write_weights(
         groups, TMP_DIR, shard_size_bytes=2 * 4)
-    manifest = json.loads(manifest_json)
 
     self.assertTrue(
         os.path.isfile(os.path.join(TMP_DIR, 'weights_manifest.json')),
@@ -146,9 +143,8 @@ class TestWriteWeights(unittest.TestCase):
     ]
 
     # Shard size is larger than the sum of the two weights so they get packed.
-    manifest_json = write_weights.write_weights(
+    manifest = write_weights.write_weights(
         groups, TMP_DIR, shard_size_bytes=8 * 4)
-    manifest = json.loads(manifest_json)
 
     self.assertTrue(
         os.path.isfile(os.path.join(TMP_DIR, 'weights_manifest.json')),
@@ -189,9 +185,8 @@ class TestWriteWeights(unittest.TestCase):
     # Shard size is smaller than the sum of the weights so they get packed and
     # then sharded. The two buffers will get sharded into 3 files, with shapes
     # [2], [2], and [1]. The second shard is a mixed dtype.
-    manifest_json = write_weights.write_weights(
+    manifest = write_weights.write_weights(
         groups, TMP_DIR, shard_size_bytes=2 * 4)
-    manifest = json.loads(manifest_json)
 
     self.assertTrue(
         os.path.isfile(os.path.join(TMP_DIR, 'weights_manifest.json')),
@@ -255,9 +250,8 @@ class TestWriteWeights(unittest.TestCase):
         }]
     ]
 
-    manifest_json = write_weights.write_weights(
+    manifest = write_weights.write_weights(
         groups, TMP_DIR, shard_size_bytes=4 * 4)
-    manifest = json.loads(manifest_json)
 
     self.assertTrue(
         os.path.isfile(os.path.join(TMP_DIR, 'weights_manifest.json')),
@@ -323,9 +317,8 @@ class TestWriteWeights(unittest.TestCase):
         }]
     ]
 
-    manifest_json = write_weights.write_weights(
+    manifest = write_weights.write_weights(
         groups, TMP_DIR, write_manifest=False)
-    manifest = json.loads(manifest_json)
 
     self.assertFalse(
         os.path.isfile(os.path.join(TMP_DIR, 'weights_manifest.json')),
@@ -422,9 +415,8 @@ class TestWriteWeights(unittest.TestCase):
         }]
     ]
 
-    manifest_json = write_weights.write_weights(
+    manifest = write_weights.write_weights(
         groups, TMP_DIR, shard_size_bytes=8 * 4, quantization_dtype=np.uint8)
-    manifest = json.loads(manifest_json)
 
     self.assertTrue(
         os.path.isfile(os.path.join(TMP_DIR, 'weights_manifest.json')),

--- a/python/test_pip_package.py
+++ b/python/test_pip_package.py
@@ -492,7 +492,7 @@ class APIAndShellTest(tf.test.TestCase):
       model_2 = tfjs.converters.load_keras_model(
           os.path.join(self._tmp_dir, 'model.json'))
       model_2_json = model_2.to_json()
-      self.assertEqual(model_json, model_2_json)   
+      self.assertEqual(model_json, model_2_json)
 
   def testVersion(self):
     process = subprocess.Popen(
@@ -656,8 +656,8 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
           stderr=subprocess.PIPE)
       _, stderr = process.communicate()
       self.assertIn(
-          'Expected path to point to an HDF5 file, '
-          'but it points to a directory', stderr)
+          b'Expected path to point to an HDF5 file, '
+          b'but it points to a directory', tf.compat.as_bytes(stderr))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
General approach:
- Load the tf.keras SavedModel and temporarily save it as a HDF5 (.h5) file. Then the .h5 file can be
  converted to tfjs format with existing logic. This reduces future maintenance overhead.

Also in this PR:
- Simplify the return type of `write_weights.write_weights()`. Let it return a dict, instead of a str,
  so that call sites won't have to parse the JSON string.
- Upgrade tensorflow dependency: 1.11.0 --> 1.12.0

Towards: https://github.com/tensorflow/tfjs/issues/857

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/244)
<!-- Reviewable:end -->
