### PR TITLE
Fixed async execute failed due to weights get disposed prematurely

### DIFF
--- a/src/executor/graph_executor.ts
+++ b/src/executor/graph_executor.ts
@@ -181,9 +181,11 @@ export class GraphExecutor {
   }
 
   private getFrozenTensorIds(tensorMap: NamedTensorsMap): Set<number> {
-    const ids = Object.keys(tensorMap)
-                    .map(key => tensorMap[key])
-                    .map(tensors => tensors.map(tensor => tensor.id));
+    const ids = [].concat.apply(
+        [],
+        Object.keys(tensorMap)
+            .map(key => tensorMap[key])
+            .map(tensors => tensors.map(tensor => tensor.id)));
     return new Set(...ids);
   }
   private checkTensorForDisposal(

--- a/src/executor/graph_executor.ts
+++ b/src/executor/graph_executor.ts
@@ -186,7 +186,7 @@ export class GraphExecutor {
         Object.keys(tensorMap)
             .map(key => tensorMap[key])
             .map(tensors => tensors.map(tensor => tensor.id)));
-    return new Set(...ids);
+    return new Set(ids);
   }
   private checkTensorForDisposal(
       nodeName: string, node: Node, tensorMap: NamedTensorsMap,

--- a/src/executor/graph_executor_test.ts
+++ b/src/executor/graph_executor_test.ts
@@ -304,7 +304,8 @@ describe('GraphExecutor', () => {
                   });
         });
 
-        it('should execute control flow graph with intermediate node',
+        it('should be able to execute control flow graph ' +
+               'with intermediate node more than once',
            (done) => {
              const inputTensor = tfc.scalar(1);
 
@@ -312,7 +313,15 @@ describe('GraphExecutor', () => {
                  .then(
                      result => {
                        tfc.test_util.expectArraysClose(result['output:1'], [1]);
-                       done();
+                       executor
+                           .executeAsync(
+                               {intermediate: [inputTensor]}, 'output:1')
+                           .then(result => {
+                             tfc.test_util.expectArraysClose(
+                                 result['output:1'], [1]);
+
+                             done();
+                           });
                      },
                      e => {
                        fail(e);


### PR DESCRIPTION
The frozen tensor id map is not constructed properly, and causes the weight
tensors to be deleted prematurely.

fixed https://github.com/tensorflow/tfjs/issues/897

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/250)
<!-- Reviewable:end -->
