### PR TITLE
added weight np dtype support for int64 and float64

### DIFF
--- a/python/tensorflowjs/quantization_test.py
+++ b/python/tensorflowjs/quantization_test.py
@@ -90,6 +90,44 @@ class TestQuantizationUtil(unittest.TestCase):
     self._runQuantizeTest(1, 3, np.int32, np.uint8, expected_scale=2/255)
     self._runQuantizeTest(1, 3, np.int32, np.uint16, expected_scale=2/65536)
 
+  def testQuantizeNegativeFloat64s(self):
+    self._runQuantizeTest(-3, -1, np.float64, np.uint8, expected_scale=2/255)
+    self._runQuantizeTest(-3, -1, np.float64, np.uint16, expected_scale=2/65536)
 
+  def testQuantizeNegativeAndZeroFloat64s(self):
+    self._runQuantizeTest(-3, 0, np.float64, np.uint8, expected_scale=3/255)
+    self._runQuantizeTest(-3, 0, np.float64, np.uint16, expected_scale=3/65536)
+
+  def testQuantizeNegativeAndPositiveFloat64s(self):
+    self._runQuantizeTest(-3, 3, np.float64, np.uint8, expected_scale=6/255)
+    self._runQuantizeTest(-3, 3, np.float64, np.uint16, expected_scale=6/65536)
+
+  def testQuantizeZeroAndPositiveFloat64s(self):
+    self._runQuantizeTest(0, 3, np.float64, np.uint8, expected_scale=3/255)
+    self._runQuantizeTest(0, 3, np.float64, np.uint16, expected_scale=3/65536)
+
+  def testQuantizePositiveFloat64s(self):
+    self._runQuantizeTest(1, 3, np.float64, np.uint8, expected_scale=2/255)
+    self._runQuantizeTest(1, 3, np.float64, np.uint16, expected_scale=2/65536)
+
+  def testQuantizeNegativeInt64s(self):
+    self._runQuantizeTest(-3, -1, np.int64, np.uint8, expected_scale=2/255)
+    self._runQuantizeTest(-3, -1, np.int64, np.uint16, expected_scale=2/65536)
+
+  def testQuantizeNegativeAndZeroInt64s(self):
+    self._runQuantizeTest(-3, 0, np.int64, np.uint8, expected_scale=3/255)
+    self._runQuantizeTest(-3, 0, np.int64, np.uint16, expected_scale=3/65536)
+
+  def testQuantizeNegativeAndPositiveInt64s(self):
+    self._runQuantizeTest(-3, 3, np.int64, np.uint8, expected_scale=6/255)
+    self._runQuantizeTest(-3, 3, np.int64, np.uint16, expected_scale=6/65536)
+
+  def testQuantizeZeroAndPositiveInt64s(self):
+    self._runQuantizeTest(0, 3, np.int64, np.uint8, expected_scale=3/255)
+    self._runQuantizeTest(0, 3, np.int64, np.uint16, expected_scale=3/65536)
+
+  def testQuantizePositiveInt64s(self):
+    self._runQuantizeTest(1, 3, np.int64, np.uint8, expected_scale=2/255)
+    self._runQuantizeTest(1, 3, np.int64, np.uint16, expected_scale=2/65536)
 if __name__ == '__main__':
   unittest.main()

--- a/python/tensorflowjs/read_weights.py
+++ b/python/tensorflowjs/read_weights.py
@@ -24,8 +24,8 @@ import os
 import numpy as np
 from tensorflowjs import quantization
 
-_INPUT_DTYPES = [np.float32, np.int32, np.uint8, np.uint16]
-
+_INPUT_DTYPES = [np.float64, np.int64,
+                 np.float32, np.int32, np.uint8, np.uint16]
 
 def read_weights(weights_manifest, base_path, flatten=False):
   """Load weight values according to a TensorFlow.js weights manifest.

--- a/python/tensorflowjs/read_weights_test.py
+++ b/python/tensorflowjs/read_weights_test.py
@@ -96,6 +96,29 @@ class ReadWeightsTest(unittest.TestCase):
     self.assertEqual('weight2', read_output[1]['name'])
     self.assertTrue(np.allclose(groups[0][1]['data'], read_output[1]['data']))
 
+  def testReadOneGroupWith64bitDataFlattened(self):
+    groups = [
+        [{
+            'name': 'weight1',
+            'data': np.array([1, 2, 3], 'float64')
+        }, {
+            'name': 'weight2',
+            'data': np.array([10, 20, 30], 'int64')
+        }]
+    ]
+
+    manifest = write_weights.write_weights(groups, self._tmp_dir)
+
+    # Read the weights using `read_weights`.
+    read_output = read_weights.read_weights(
+        manifest, self._tmp_dir, flatten=True)
+    self.assertEqual(2, len(read_output))
+    self.assertEqual('weight1', read_output[0]['name'])
+    self.assertTrue(np.allclose(groups[0][0]['data'], read_output[0]['data']))
+    self.assertEqual('weight2', read_output[1]['name'])
+    self.assertTrue(np.allclose(groups[0][1]['data'], read_output[1]['data']))
+
+
   def testReadTwoGroupsFlattend(self):
     groups = [
         [{

--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -21,7 +21,7 @@ import os
 import numpy as np
 from tensorflowjs import quantization
 
-_OUTPUT_DTYPES = [np.float32, np.int32, np.uint8, np.uint16, np.bool]
+_OUTPUT_DTYPES = [np.float64, np.int64, np.float32, np.int32, np.uint8, np.uint16, np.bool]
 
 def write_weights(
     weight_groups, write_dir, shard_size_bytes=1024 * 1024 * 4,

--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -21,11 +21,12 @@ import os
 import numpy as np
 from tensorflowjs import quantization
 
-_OUTPUT_DTYPES = [np.float64, np.int64, np.float32, np.int32, np.uint8, np.uint16, np.bool]
+_OUTPUT_DTYPES = [np.float64, np.int64, np.float32,
+                  np.int32, np.uint8, np.uint16, np.bool]
 
 def write_weights(
-    weight_groups, write_dir, shard_size_bytes=1024 * 1024 * 4,
-    write_manifest=True, quantization_dtype=None):
+        weight_groups, write_dir, shard_size_bytes=1024 * 1024 * 4,
+        write_manifest=True, quantization_dtype=None):
   """Writes weights to a binary format on disk for ingestion by JavaScript.
 
     Weights are organized into groups. When writing to disk, the bytes from all
@@ -131,6 +132,7 @@ def write_weights(
 
   return manifest
 
+
 def _quantize_entry(entry, quantization_dtype):
   """Quantizes the weights in the entry, returning a new entry.
 
@@ -169,6 +171,7 @@ def _quantize_entry(entry, quantization_dtype):
       'min': min_val, 'scale': scale, 'original_dtype': data.dtype.name}
   return quantized_entry
 
+
 def _stack_group_bytes(group):
   """Stacks the bytes for a weight group into a flat byte array.
 
@@ -203,7 +206,7 @@ def _stack_group_bytes(group):
 
 
 def _shard_group_bytes_to_disk(
-    write_dir, group_index, group_bytes, total_bytes, shard_size_bytes):
+        write_dir, group_index, group_bytes, total_bytes, shard_size_bytes):
   """Shards the concatenated bytes for a group to disk.
 
   Args:
@@ -309,11 +312,11 @@ def _assert_weight_groups_valid(weight_groups):
             'weight_groups[' + i + '][' + j + '] has no string field \'name\'')
       if 'data' not in weights:
         raise ValueError(
-            'weight_groups[' + i + '][' + j + '] has no numpy ' + \
+            'weight_groups[' + i + '][' + j + '] has no numpy ' +
             'array field \'data\'')
       if not isinstance(weights['data'], np.ndarray):
         raise ValueError(
-            'weight_groups[' + i + '][' + j + '][\'data\'] is not a numpy ' + \
+            'weight_groups[' + i + '][' + j + '][\'data\'] is not a numpy ' +
             'array')
 
 

--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -25,8 +25,8 @@ _OUTPUT_DTYPES = [np.float64, np.int64, np.float32,
                   np.int32, np.uint8, np.uint16, np.bool]
 
 def write_weights(
-        weight_groups, write_dir, shard_size_bytes=1024 * 1024 * 4,
-        write_manifest=True, quantization_dtype=None):
+    weight_groups, write_dir, shard_size_bytes=1024 * 1024 * 4,
+    write_manifest=True, quantization_dtype=None):
   """Writes weights to a binary format on disk for ingestion by JavaScript.
 
     Weights are organized into groups. When writing to disk, the bytes from all
@@ -206,7 +206,7 @@ def _stack_group_bytes(group):
 
 
 def _shard_group_bytes_to_disk(
-        write_dir, group_index, group_bytes, total_bytes, shard_size_bytes):
+    write_dir, group_index, group_bytes, total_bytes, shard_size_bytes):
   """Shards the concatenated bytes for a group to disk.
 
   Args:

--- a/python/tensorflowjs/write_weights_test.py
+++ b/python/tensorflowjs/write_weights_test.py
@@ -234,7 +234,7 @@ class TestWriteWeights(unittest.TestCase):
         # Group 1
         [{
             'name': 'weight1',
-            'data': np.array([1, 2, 3], 'float32')
+            'data': np.array([1, 2], 'float64')
         }, {
             'name': 'weight2',
             'data': np.array([[4, 5], [6, 7]], 'float32')
@@ -245,7 +245,10 @@ class TestWriteWeights(unittest.TestCase):
             'data': np.array([1, 2, 3, 4], 'int32')
         }, {
             'name': 'weight4',
-            'data': np.array([[1.1, 1.2], [1.3, 1.4], [1.5, 1.6]], 'float32')
+            'data': np.array([[1.1, 1.2], [1.3, 1.4]], 'float32')
+        }, {
+            'name': 'weight5',
+            'data': np.array([1], 'int64')
         }]
     ]
 
@@ -261,8 +264,8 @@ class TestWriteWeights(unittest.TestCase):
             'paths': ['group1-shard1of2', 'group1-shard2of2'],
             'weights': [{
                 'name': 'weight1',
-                'shape': [3],
-                'dtype': 'float32'
+                'shape': [2],
+                'dtype': 'float64'
             }, {
                 'name': 'weight2',
                 'shape': [2, 2],
@@ -278,20 +281,24 @@ class TestWriteWeights(unittest.TestCase):
                 'dtype': 'int32'
             }, {
                 'name': 'weight4',
-                'shape': [3, 2],
+                'shape': [2, 2],
                 'dtype': 'float32'
+            }, {
+                'name': 'weight5',
+                'shape': [1],
+                'dtype': 'int64'
             }]
         }])
 
     group0_shard_1_path = os.path.join(TMP_DIR, 'group1-shard1of2')
-    group0_shard_1 = np.fromfile(group0_shard_1_path, 'float32')
+    group0_shard_1 = np.fromfile(group0_shard_1_path, 'float64')
     np.testing.assert_array_equal(
-        group0_shard_1, np.array([1, 2, 3, 4], 'float32'))
+        group0_shard_1, np.array([1, 2], 'float64'))
 
     group0_shard_2_path = os.path.join(TMP_DIR, 'group1-shard2of2')
     group0_shard_2 = np.fromfile(group0_shard_2_path, 'float32')
     np.testing.assert_array_equal(
-        group0_shard_2, np.array([5, 6, 7], 'float32'))
+        group0_shard_2, np.array([4, 5, 6, 7], 'float32'))
 
     group1_shard_1_path = os.path.join(TMP_DIR, 'group2-shard1of3')
     group1_shard_1 = np.fromfile(group1_shard_1_path, 'int32')
@@ -304,9 +311,9 @@ class TestWriteWeights(unittest.TestCase):
         group2_shard_2, np.array([1.1, 1.2, 1.3, 1.4], 'float32'))
 
     group2_shard_3_path = os.path.join(TMP_DIR, 'group2-shard3of3')
-    group2_shard_3 = np.fromfile(group2_shard_3_path, 'float32')
+    group2_shard_3 = np.fromfile(group2_shard_3_path, 'int64')
     np.testing.assert_array_equal(
-        group2_shard_3, np.array([1.5, 1.6], 'float32'))
+        group2_shard_3, np.array([1], 'int64'))
 
   def test_no_write_manfest(self):
     groups = [
@@ -382,7 +389,7 @@ class TestWriteWeights(unittest.TestCase):
     groups = [
         [{
             'name': 'weight1',
-            'data': np.array([1, 2, 3], 'float64')
+            'data': np.array([1, 2, 3], 'complex')
         }]
     ]
 


### PR DESCRIPTION
ref https://github.com/tensorflow/tfjs/issues/970
The converter will support the conversion of int64 and float64, while in the model loader, those two types will be lowered to int32 and float32, and warning will be given in the console.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/267)
<!-- Reviewable:end -->
