### PR TITLE
Standardize karma start across packages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "link-local": "yalc link",
     "publish-local": "yarn build-npm && yalc push",
     "test": "karma start",
-    "test-travis": "karma start --browsers='bs_firefox_mac,bs_chrome_mac' --singleRun",
+    "test-travis": "karma start --singleRun --reporters='dots,karma-typescript,BrowserStack'",
     "lint": "tslint -p . -t verbose",
     "make-version": "sh -c ./scripts/make-version",
     "gen-doc": "ts-node ./scripts/gen_doc.ts",


### PR DESCRIPTION
For some reason the converter is throwing an internalBinding error when running karma from integration tests.. this is the only difference I see (all are running on Node 10, the yarn.lock and package.json files have the same karma-browserstack-launcher dependency).