### PR TITLE
support unknown rank field for json model

### DIFF
--- a/src/executor/tensor_array.ts
+++ b/src/executor/tensor_array.ts
@@ -120,7 +120,8 @@ export class TensorArray {
     }
 
     // Set the shape for the first time write to unknow shape tensor array
-    if (this.size() === 0 && this.elementShape.length === 0) {
+    if (this.size() === 0 &&
+        (this.elementShape == null || this.elementShape.length === 0)) {
       this.elementShape = tensor.shape;
     }
 

--- a/src/executor/tensor_array_test.ts
+++ b/src/executor/tensor_array_test.ts
@@ -74,6 +74,14 @@ describe('TensorArray', () => {
       const tensor = tensor2d([1, 2], [2, 1], 'int32');
       expect(() => tensorArray.write(0, tensor)).toThrow();
     });
+    it('should allow unknown shape', () => {
+      const unknownShape: number[] = undefined;
+      tensorArray = new TensorArray(
+          NAME, DTYPE, SIZE, unknownShape, IDENTICAL_SHAPE, DYNAMIC_SIZE,
+          CLEAR_AFTER_READ);
+      const tensor = tensor2d([1, 2], [2, 1], 'int32');
+      expect(() => tensorArray.write(0, tensor)).not.toThrow();
+    });
     it('should fail if the index has already been written', () => {
       tensorArray.write(0, tensor);
       expect(() => tensorArray.write(0, tensor)).toThrow();

--- a/src/operations/operation_mapper_json.ts
+++ b/src/operations/operation_mapper_json.ts
@@ -275,10 +275,15 @@ export class OperationMapper {
       def?: number[]): number[]|undefined {
     const param = attrs[name];
     if (param && param.shape) {
-      return param.shape.dim.map(
-          dim => (typeof dim.size === 'number') ?
-              dim.size :
-              parseInt(dim.size as string, 10));
+      if (param.shape.unknownRank) {
+        return undefined;
+      }
+      if (param.shape.dim) {
+        return param.shape.dim.map(
+            dim => (typeof dim.size === 'number') ?
+                dim.size :
+                parseInt(dim.size as string, 10));
+      }
     }
     return def;
   }

--- a/src/operations/operation_mapper_json.ts
+++ b/src/operations/operation_mapper_json.ts
@@ -278,7 +278,7 @@ export class OperationMapper {
       if (param.shape.unknownRank) {
         return undefined;
       }
-      if (param.shape.dim) {
+      if (param.shape.dim != null) {
         return param.shape.dim.map(
             dim => (typeof dim.size === 'number') ?
                 dim.size :


### PR DESCRIPTION
With JSON model the TensorArray dim attr can be undefined, but the unknownRank field will be set.
Added support for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/284)
<!-- Reviewable:end -->
