### PR TITLE
Preserve docs in npm package

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "moduleResolution": "node",
     "noImplicitAny": true,
     "sourceMap": true,
-    "removeComments": true,
+    "removeComments": false,
     "preserveConstEnums": true,
     "declaration": true,
     "target": "es5",


### PR DESCRIPTION
This fixes https://github.com/tensorflow/tfjs/issues/1180 and allows users to see docs in code editors like vscode.

Note that the docs are still removed from the minified bundle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/285)
<!-- Reviewable:end -->
