### PR TITLE
Fixed dtype requirement errors for gather and sparseToDense ops

### DIFF
--- a/src/operations/executors/slice_join_executor.ts
+++ b/src/operations/executors/slice_join_executor.ts
@@ -151,7 +151,9 @@ export let executeOp: OpExecutor = (node: Node, tensorMap: NamedTensorsMap,
           getParamValue('defaultValue', node, tensorMap, context) as tfc.Scalar;
       return [tfc.sparseToDense(
           indices, sparseValues, shape,
-          defaultValue.asType(sparseValues.dtype))];
+          sparseValues.dtype === defaultValue.dtype ?
+              defaultValue :
+              defaultValue.asType(sparseValues.dtype))];
     }
     default:
       throw TypeError(`Node type ${node.op} is not implemented`);

--- a/src/operations/executors/slice_join_executor.ts
+++ b/src/operations/executors/slice_join_executor.ts
@@ -39,7 +39,7 @@ export let executeOp: OpExecutor = (node: Node, tensorMap: NamedTensorsMap,
       const input = getParamValue('x', node, tensorMap, context) as tfc.Tensor;
       const indices =
           getParamValue('indices', node, tensorMap, context) as tfc.Tensor1D;
-      return [tfc.gather(input, indices, axis)];
+      return [tfc.gather(input, indices.asType('int32'), axis)];
     }
     case 'reverse': {
       const axis = getParamValue('axis', node, tensorMap, context) as number[];
@@ -149,7 +149,9 @@ export let executeOp: OpExecutor = (node: Node, tensorMap: NamedTensorsMap,
           getParamValue('sparseValues', node, tensorMap, context) as tfc.Tensor;
       const defaultValue =
           getParamValue('defaultValue', node, tensorMap, context) as tfc.Scalar;
-      return [tfc.sparseToDense(indices, sparseValues, shape, defaultValue)];
+      return [tfc.sparseToDense(
+          indices, sparseValues, shape,
+          defaultValue.asType(sparseValues.dtype))];
     }
     default:
       throw TypeError(`Node type ${node.op} is not implemented`);

--- a/src/operations/executors/slice_join_executor_test.ts
+++ b/src/operations/executors/slice_join_executor_test.ts
@@ -221,10 +221,28 @@ describe('slice join', () => {
         node.op = 'gather';
         node.params.indices = createTensorAttr(1);
         node.params.axis = createNumberAttrFromIndex(2);
-        node.inputNames = ['input1', 'input2', 'input3'];
-        executeOp(node, {input1, input2, input3}, context);
+        const input5 = [tfc.scalar(2, 'int32')];
+        node.inputNames = ['input1', 'input5', 'input3'];
+        executeOp(node, {input1, input5, input3}, context);
 
-        expect(tfc.gather).toHaveBeenCalledWith(input1[0], input2[0], 3);
+        expect(tfc.gather)
+            .toHaveBeenCalledWith(
+                input1[0], jasmine.objectContaining({dataId: input5[0].dataId}),
+                3);
+      });
+
+      it('should make indices param of int32 dtype', () => {
+        spyOn(tfc, 'gather');
+        node.op = 'gather';
+        node.params.indices = createTensorAttr(1);
+        node.params.axis = createNumberAttrFromIndex(2);
+        node.inputNames = ['input1', 'input5', 'input3'];
+        const input5 = [tfc.scalar(2, 'float32')];
+        executeOp(node, {input1, input5, input3}, context);
+
+        expect(tfc.gather)
+            .toHaveBeenCalledWith(
+                input1[0], jasmine.objectContaining({dtype: 'int32'}), 3);
       });
       it('should match json def for gather', () => {
         node.op = 'gather';
@@ -324,6 +342,23 @@ describe('slice join', () => {
 
         expect(tfc.sparseToDense)
             .toHaveBeenCalledWith(input1[0], input3[0], [3], input2[0]);
+      });
+      it('should make defaultValue of same dtype as sparseValues', () => {
+        spyOn(tfc, 'sparseToDense');
+        node.op = 'sparseToDense';
+        node.params.sparseIndices = createTensorAttr(0);
+        node.params.outputShape = createNumericArrayAttrFromIndex(1);
+        node.params.sparseValues = createTensorAttr(2);
+        node.params.defaultValue = createTensorAttr(3);
+        node.params.indices = createTensorAttr(1);
+        const input5 = [tfc.scalar(5, 'int32')];
+        node.inputNames = ['input1', 'input4', 'input3', 'input5'];
+        executeOp(node, {input1, input5, input3, input4}, context);
+
+        expect(tfc.sparseToDense)
+            .toHaveBeenCalledWith(
+                input1[0], input3[0], [3],
+                jasmine.objectContaining({dtype: 'float32'}));
       });
       it('should match json def for sparseToDense', () => {
         node.op = 'sparseToDense';

--- a/src/operations/operation_mapper_json.ts
+++ b/src/operations/operation_mapper_json.ts
@@ -138,7 +138,7 @@ export class OperationMapper {
       params: {}
     };
 
-    if (!!mapper.params) {
+    if (mapper.params != null && node.attr != null) {
       newNode.params = mapper.params.reduce<{[key: string]:
                                                  ParamValue}>((map, param) => {
         const inputIndex = param.tfInputIndex;

--- a/src/operations/operation_mapper_json.ts
+++ b/src/operations/operation_mapper_json.ts
@@ -137,14 +137,18 @@ export class OperationMapper {
       children: [],
       params: {}
     };
+    if (node.attr == null) {
+      node.attr = {};
+    }
 
-    if (mapper.params != null && node.attr != null) {
+    if (mapper.params != null) {
       newNode.params = mapper.params.reduce<{[key: string]:
                                                  ParamValue}>((map, param) => {
         const inputIndex = param.tfInputIndex;
         const inputParamLength = param.tfInputParamLength;
         const type = param.type;
         let value = undefined;
+
         if (inputIndex === undefined) {
           switch (param.type) {
             case 'string':

--- a/src/operations/operation_mapper_json_test.ts
+++ b/src/operations/operation_mapper_json_test.ts
@@ -123,7 +123,7 @@ const SIMPLE_MODEL: tensorflow_json.IGraphDef = {
       input: ['image_placeholder'],
       attr: {num_split: {i: 3} as tensorflow_json.IAttrValue}
     },
-    {
+    {name: 'LogicalNot', op: 'LogicalNot', input: ['image_placeholder']}, {
       name: 'FusedBatchNorm',
       op: 'FusedBatchNorm',
       input: ['image_placeholder'],
@@ -163,7 +163,7 @@ describe('operationMapper', () => {
 
       it('should find the graph output nodes', () => {
         expect(convertedGraph.outputs.map(node => node.name)).toEqual([
-          'Fill', 'Squeeze', 'Split', 'FusedBatchNorm'
+          'Fill', 'Squeeze', 'Split', 'LogicalNot', 'FusedBatchNorm'
         ]);
       });
 
@@ -176,7 +176,7 @@ describe('operationMapper', () => {
       it('should convert nodes', () => {
         expect(Object.keys(convertedGraph.nodes)).toEqual([
           'image_placeholder', 'Const', 'Shape', 'Value', 'Fill', 'Conv2D',
-          'BiasAdd', 'Squeeze', 'Split', 'FusedBatchNorm'
+          'BiasAdd', 'Squeeze', 'Split', 'LogicalNot', 'FusedBatchNorm'
         ]);
       });
     });
@@ -189,7 +189,7 @@ describe('operationMapper', () => {
       it('should find the children nodes', () => {
         expect(convertedGraph.nodes['image_placeholder'].children.map(
                    node => node.name))
-            .toEqual(['Conv2D', 'Split', 'FusedBatchNorm']);
+            .toEqual(['Conv2D', 'Split', 'LogicalNot', 'FusedBatchNorm']);
       });
 
       it('should map the input params', () => {


### PR DESCRIPTION
The gather op requires the indices to have int32 dtype, sparseToDense requires the defaultValue to have the same dtype as the sparseValues.

Cast the tensors for those params to the correct dtype.
Also allow graph node to have empty attr field, this is possible for JSON models.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/288)
<!-- Reviewable:end -->
