### PR TITLE
Update tfjs-converter to 1.0.0-alpha2 at master and point to tfjs-core@1.0.0-alpha2. Also update to tfc.batchNorm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensorflow/tfjs-converter",
-  "version": "1.0.0-alpha1",
+  "version": "1.0.0-alpha2",
   "description": "Tensorflow model converter for javascript",
   "main": "dist/src/index.js",
   "jsnext:main": "dist/tf-converter.esm.js",
@@ -14,10 +14,10 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "1.0.0-alpha1"
+    "@tensorflow/tfjs-core": "1.0.0-alpha2"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "1.0.0-alpha1",
+    "@tensorflow/tfjs-core": "1.0.0-alpha2",
     "@types/jasmine": "~2.8.6",
     "@types/js-base64": "2.3.1",
     "@types/node-fetch": "1.6.9",

--- a/python/tensorflowjs/version.py
+++ b/python/tensorflowjs/version.py
@@ -1,4 +1,4 @@
 # @license See the LICENSE file.
 
 # This code is auto-generated, do not modify this file!
-version = '1.0.0-alpha1'
+version = '1.0.0-alpha2'

--- a/src/operations/executors/normalization_executor.ts
+++ b/src/operations/executors/normalization_executor.ts
@@ -29,13 +29,13 @@ export let executeOp: OpExecutor = (node: Node, tensorMap: NamedTensorsMap,
                                        tfc.Tensor[] => {
   switch (node.op) {
     case 'batchNormalization': {
-      return [tfc.batchNormalization(
+      return [tfc.batchNorm(
           getParamValue('x', node, tensorMap, context) as tfc.Tensor,
           getParamValue('mean', node, tensorMap, context) as tfc.Tensor,
           getParamValue('variance', node, tensorMap, context) as tfc.Tensor,
-          getParamValue('epsilon', node, tensorMap, context) as number,
+          getParamValue('offset', node, tensorMap, context) as tfc.Tensor,
           getParamValue('scale', node, tensorMap, context) as tfc.Tensor,
-          getParamValue('offset', node, tensorMap, context) as tfc.Tensor)];
+          getParamValue('epsilon', node, tensorMap, context) as number)];
     }
     case 'localResponseNormalization': {
       return [tfc.localResponseNormalization(

--- a/src/operations/executors/normalization_executor_test.ts
+++ b/src/operations/executors/normalization_executor_test.ts
@@ -43,8 +43,8 @@ describe('normalization', () => {
 
   describe('executeOp', () => {
     describe('batchNormalization', () => {
-      it('should call tfc.batchNormalization', () => {
-        spyOn(tfc, 'batchNormalization');
+      it('should call tfc.batchNorm', () => {
+        spyOn(tfc, 'batchNorm');
         node.op = 'batchNormalization';
         node.params.scale = createTensorAttr(1);
         node.params.offset = createTensorAttr(2);
@@ -58,9 +58,9 @@ describe('normalization', () => {
         const input5 = [tfc.scalar(4)];
         executeOp(node, {input1, input2, input3, input4, input5}, context);
 
-        expect(tfc.batchNormalization)
+        expect(tfc.batchNorm)
             .toHaveBeenCalledWith(
-                input1[0], input4[0], input5[0], 5, input2[0], input3[0]);
+                input1[0], input4[0], input5[0], input3[0], input2[0], 5);
       });
     });
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 /** @license See the LICENSE file. */
 
 // This code is auto-generated, do not modify this file!
-const version = '1.0.0-alpha1';
+const version = '1.0.0-alpha2';
 export {version};

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,10 +55,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@tensorflow/tfjs-core@1.0.0-alpha1":
-  version "1.0.0-alpha1"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.0.0-alpha1.tgz#ad0174b68d294d4297e47d436d055f9b57143d8c"
-  integrity sha512-cl3BNB3VAmfWhDeZr9jwhdgOOxYgHa7XvfPWyDZy0pAkIP+KXdOzNnSCyFkGFK1Xlj1ptObDfLIV48iMnOSQiQ==
+"@tensorflow/tfjs-core@1.0.0-alpha2":
+  version "1.0.0-alpha2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.0.0-alpha2.tgz#6f048392c72ae05950bb61401305534a2ea95d58"
+  integrity sha512-BJ91Wuj772KM03/XxJFGSYjZIjIITy9Fci04AWVZRwHkdyHe07rLClHNwsCdHvAkhom8+vSvcOPR95Y7PQ2tdA==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"


### PR DESCRIPTION
This PR also switches the converter over to the new tfc.batchNorm with the reordered arguments.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/292)
<!-- Reviewable:end -->
