### PR TITLE
Copy paste the body of loadFrozenModel to loadGraphModel

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,20 @@ export function loadGraphModel(
   if (options != null && options.fromTFHub) {
     return loadTfHubModule(modelUrl, options.requestInit, options.onProgress);
   }
-  const manifestUrl: string = undefined;
-  return loadFrozenModel(
-      modelUrl, manifestUrl, options.requestInit, options.onProgress);
+  let weightsManifestUrl: string = undefined;
+
+  if (modelUrl && modelUrl.endsWith('.json')) {
+    return (loadFrozenModelJSON(
+                modelUrl, options.requestInit, options.onProgress) as
+                // tslint:disable-next-line:no-any
+                Promise<any>) as Promise<FrozenModel>;
+  }
+  // if users are using the new loadGraphModel API, the weightManifestUrl will
+  // be omitted. We will build the url using the model URL path and default
+  // manifest file name.
+  if (modelUrl != null && weightsManifestUrl == null) {
+    weightsManifestUrl = getWeightsManifestUrl(modelUrl);
+  }
+  return loadFrozenModelPB(
+      modelUrl, weightsManifestUrl, options.requestInit, options.onProgress);
 }


### PR DESCRIPTION
This allows us to throw a deprecation warn on the loadFrozenModel code path without warning on the loadGraphModel code path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/298)
<!-- Reviewable:end -->
