### PR TITLE
Remove js-base64 external dep which breaks the library

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "devDependencies": {
     "@tensorflow/tfjs-core": "1.0.0-alpha3",
     "@types/jasmine": "~2.8.6",
-    "@types/js-base64": "2.3.1",
     "@types/node-fetch": "1.6.9",
     "ajv": "~6.3.0",
     "babel-core": "~6.26.3",
@@ -64,7 +63,6 @@
   },
   "dependencies": {
     "@types/long": "~3.0.32",
-    "js-base64": "2.4.9",
     "protobufjs": "~6.8.6"
   }
 }

--- a/rollup.config.google.js
+++ b/rollup.config.google.js
@@ -48,11 +48,7 @@ export default {
     plugins: [
       node(),
       // Polyfill require() from dependencies.
-      commonjs({
-        namedExports: {
-          './node_modules/base64/index.js': ['Base64']
-        }
-      }),
+      commonjs({}),
       cleanup({comments: 'none'}),
     ],
     output: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,8 +55,7 @@ function config({plugins = [], output = {}}) {
       commonjs({
         namedExports: {
           './src/data/compiled_api.js': ['tensorflow'],
-          './node_modules/protobufjs/minimal.js': ['roots', 'Reader', 'util'],
-          './node_modules/base64/index.js': ['Base64']
+          './node_modules/protobufjs/minimal.js': ['roots', 'Reader', 'util']
         }
       }),
       ...plugins

--- a/src/operations/operation_mapper_json.ts
+++ b/src/operations/operation_mapper_json.ts
@@ -237,7 +237,7 @@ export class OperationMapper {
     } else {
       throw new Error(
           'Unable to decode base64 in this environment. ' +
-          'Missing built-ins atob() or Buffer()');
+          'Missing built-in atob() or Buffer()');
     }
   }
 

--- a/src/operations/operation_mapper_json.ts
+++ b/src/operations/operation_mapper_json.ts
@@ -14,11 +14,9 @@
  * limitations under the License.
  * =============================================================================
  */
+
 import {DataType} from '@tensorflow/tfjs-core';
-import {Base64} from 'js-base64';
-
 import {tensorflow_json} from '../data/compiled_api_json';
-
 import {getNodeNameAndIndex} from './executors/utils';
 import * as arithmetic from './op_list/arithmetic';
 import * as basicMath from './op_list/basic_math';
@@ -231,6 +229,18 @@ export class OperationMapper {
     return newNode;
   }
 
+  private decodeBase64(text: string): string {
+    if (typeof atob !== 'undefined') {
+      return atob(text);
+    } else if (typeof Buffer !== 'undefined') {
+      return new Buffer(text, 'base64').toString();
+    } else {
+      throw new Error(
+          'Unable to decode base64 in this environment. ' +
+          'Missing built-ins atob() or Buffer()');
+    }
+  }
+
   private getStringParam(
       attrs: {[key: string]: tensorflow_json.IAttrValue}, name: string,
       def: string, keepCase = false): string {
@@ -238,7 +248,7 @@ export class OperationMapper {
     if (param !== undefined) {
       const value = Array.isArray(param.s) ?
           String.fromCharCode.apply(null, param.s) :
-          Base64.decode(param.s);
+          this.decodeBase64(param.s);
       return keepCase ? value : value.toLowerCase();
     }
     return def;

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,11 +75,6 @@
   resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-2.8.7.tgz#3fe583928ae0a22cdd34cedf930eeffeda2602fd"
   integrity sha512-RdbrPcW1aD78UmdLiDa9ZCKrbR5Go8PXh6GCpb4oIOkWVEusubSJJDrP4c5RYOu8m/CBz+ygZpicj6Pgms5a4Q==
 
-"@types/js-base64@2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@types/js-base64/-/js-base64-2.3.1.tgz#c39f14f129408a3d96a1105a650d8b2b6eeb4168"
-  integrity sha512-4RKbhIDGC87s4EBy2Cp2/5S2O6kmCRcZnD5KRCq1q9z2GhBte1+BdsfVKCpG8yKpDGNyEE2G6IqFIh6W2YwWPA==
-
 "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
@@ -2971,11 +2966,6 @@ jasmine-core@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.1.0.tgz#a4785e135d5df65024dfc9224953df585bd2766c"
   integrity sha1-pHheE11d9lAk38kiSVPfWFvSdmw=
-
-js-base64@2.4.9:
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.9.tgz#748911fb04f48a60c4771b375cac45a80df11c03"
-  integrity sha512-xcinL3AuDJk7VSzsHgb9DvvIXayBbadtMZ4HFPx8rUszbW1MuNMlwYVC4zzCZ6e1sqZpnNS5ZFYOhXqA39T7LQ==
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Implement base64 decode using built-ins that work in both browser and Node.js.

The external dependency (js-base64) causes a run-time error at library load time for html pages that are missing utf-8 encoding meta tags. This is due to a regexp with non-ascii characters.

If you do `<script src="tf.min.js></script>` in an empty html page, the library fails to load. Adding `<meta charset="UTF-8">` fixes it.


I'll make sure we catch things like this in the future (https://github.com/tensorflow/tfjs/issues/1251), by adding integration tests with `<script>` tags and spinning up browsers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/306)
<!-- Reviewable:end -->
