### PR TITLE
0.8.x Use batchNorm instead of batchNormalization

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -198,8 +198,8 @@
 
 |Tensorflow Op Name|Tensorflow.js Op Name|
 |---|---|
-|FusedBatchNorm|batchNormalization|
-|FusedBatchNormV2|batchNormalization|
+|FusedBatchNorm|batchNorm|
+|FusedBatchNormV2|batchNorm|
 |LogSoftmax|logSoftmax|
 |LRN|localResponseNormalization|
 |Softmax|softmax|

--- a/src/operations/executors/normalization_executor.ts
+++ b/src/operations/executors/normalization_executor.ts
@@ -29,13 +29,13 @@ export let executeOp: OpExecutor = (node: Node, tensorMap: NamedTensorsMap,
                                        tfc.Tensor[] => {
   switch (node.op) {
     case 'batchNormalization': {
-      return [tfc.batchNormalization(
+      return [tfc.batchNorm(
           getParamValue('x', node, tensorMap, context) as tfc.Tensor,
           getParamValue('mean', node, tensorMap, context) as tfc.Tensor,
           getParamValue('variance', node, tensorMap, context) as tfc.Tensor,
-          getParamValue('epsilon', node, tensorMap, context) as number,
+          getParamValue('offset', node, tensorMap, context) as tfc.Tensor,
           getParamValue('scale', node, tensorMap, context) as tfc.Tensor,
-          getParamValue('offset', node, tensorMap, context) as tfc.Tensor)];
+          getParamValue('epsilon', node, tensorMap, context) as number)];
     }
     case 'localResponseNormalization': {
       return [tfc.localResponseNormalization(

--- a/src/operations/executors/normalization_executor_test.ts
+++ b/src/operations/executors/normalization_executor_test.ts
@@ -43,8 +43,8 @@ describe('normalization', () => {
 
   describe('executeOp', () => {
     describe('batchNormalization', () => {
-      it('should call tfc.batchNormalization', () => {
-        spyOn(tfc, 'batchNormalization');
+      it('should call tfc.batchNorm', () => {
+        spyOn(tfc, 'batchNorm');
         node.op = 'batchNormalization';
         node.params.scale = createTensorAttr(1);
         node.params.offset = createTensorAttr(2);
@@ -58,9 +58,9 @@ describe('normalization', () => {
         const input5 = [tfc.scalar(4)];
         executeOp(node, {input1, input2, input3, input4, input5}, context);
 
-        expect(tfc.batchNormalization)
+        expect(tfc.batchNorm)
             .toHaveBeenCalledWith(
-                input1[0], input4[0], input5[0], 5, input2[0], input3[0]);
+                input1[0], input4[0], input5[0], input3[0], input2[0], 5);
       });
     });
 


### PR DESCRIPTION
https://github.com/tensorflow/tfjs-converter/pull/292 never got cherry picked in 0.8.x, thus this PR.

Use batchNorm in 0.8.x instead of batchNormalization to avoid warning messages using the latest converter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/310)
<!-- Reviewable:end -->
