### PR TITLE
upgrade to tf 1.13.1 and fix the grappler and keras loader errors

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,5 +2,5 @@ h5py==2.8.0
 keras==2.2.2
 numpy==1.15.1
 six==1.11.0
-tensorflow==1.12.0
+tensorflow==1.13.1
 tensorflow_hub==0.1.1

--- a/python/tensorflowjs/converters/keras_tfjs_loader_test.py
+++ b/python/tensorflowjs/converters/keras_tfjs_loader_test.py
@@ -95,7 +95,7 @@ class LoadKerasModelTest(tf.test.TestCase):
     buff_writer.seek(0)
 
     with tf.Graph().as_default(), tf.Session():
-      model2 = keras_tfjs_loader.deserialize_keras_model(buff)
+      model2 = keras_tfjs_loader.deserialize_keras_model(buff.read())
 
       # The two model JSONs should match exactly.
       self.assertEqual(model1.to_json(), model2.to_json())
@@ -108,7 +108,7 @@ class LoadKerasModelTest(tf.test.TestCase):
       model1 = self._saveKerasModelForTest(tfjs_path)
 
     # Read the content of model.json into a BytesIO
-    with open(os.path.join(tfjs_path, 'model.json'), 'rb') as f:
+    with open(os.path.join(tfjs_path, 'model.json'), 'rt') as f:
       config_json = json.load(f)
 
     with tf.Graph().as_default(), tf.Session():
@@ -158,7 +158,7 @@ class LoadKerasModelTest(tf.test.TestCase):
       model1_weight_values = model1.get_weights()
 
     # Read the content of model.json into a file object.
-    json_file = open(os.path.join(tfjs_path, 'model.json'), 'rb')
+    json_file = open(os.path.join(tfjs_path, 'model.json'), 'rt')
 
     weight_paths = sorted(glob.glob(os.path.join(tfjs_path, 'group*')))
     weight_files = [open(path, 'rb') for path in weight_paths]

--- a/python/tensorflowjs/converters/tf_saved_model_conversion.py
+++ b/python/tensorflowjs/converters/tf_saved_model_conversion.py
@@ -25,7 +25,7 @@ import numpy as np
 import tensorflow as tf
 
 from tensorflow.core.protobuf import device_properties_pb2
-from tensorflow.core.protobuf import rewriter_config_pb2
+from tensorflow.core.protobuf import config_pb2
 from tensorflow.python.framework import graph_util
 from tensorflow.python.grappler import cluster as gcluster
 from tensorflow.python.grappler import tf_optimizer
@@ -121,7 +121,8 @@ def optimize_graph(graph,
     raise ValueError('Unsupported Ops in the model before optimization\n' +
                      ', '.join(unsupported))
 
-  rewriter_config = rewriter_config_pb2.RewriterConfig()
+  config = config_pb2.ConfigProto()
+  rewriter_config = config.graph_options.rewrite_options
   rewriter_config.optimizers[:] = [
       'pruning', 'constfold', 'arithmetic', 'dependency', 'pruning', 'remap',
       'constfold', 'arithmetic', 'dependency'
@@ -131,7 +132,7 @@ def optimize_graph(graph,
   meta_graph = tf.train.export_meta_graph(
       graph_def=graph.as_graph_def(), graph=graph)
   optimized_graph = tf_optimizer.OptimizeGraph(
-      rewriter_config, meta_graph, cluster=get_cluster())
+      config, meta_graph, cluster=get_cluster())
 
   unsupported = validate(optimized_graph.node, skip_op_check,
                          strip_debug_ops)

--- a/python/tensorflowjs/converters/tf_saved_model_conversion_pb.py
+++ b/python/tensorflowjs/converters/tf_saved_model_conversion_pb.py
@@ -24,7 +24,7 @@ import numpy as np
 
 import tensorflow as tf
 from tensorflow.core.protobuf import device_properties_pb2
-from tensorflow.core.protobuf import rewriter_config_pb2
+from tensorflow.core.protobuf import config_pb2
 from tensorflow.python.framework import graph_util
 from tensorflow.python.grappler import cluster as gcluster
 from tensorflow.python.grappler import tf_optimizer
@@ -116,7 +116,8 @@ def optimize_graph(graph,
     raise ValueError('Unsupported Ops in the model before optimization\n' +
                      ', '.join(unsupported))
 
-  rewriter_config = rewriter_config_pb2.RewriterConfig()
+  config = config_pb2.ConfigProto()
+  rewriter_config = config.graph_options.rewrite_options
   rewriter_config.optimizers[:] = [
       'pruning', 'constfold', 'arithmetic', 'dependency', 'pruning', 'remap',
       'constfold', 'arithmetic', 'dependency'
@@ -126,7 +127,7 @@ def optimize_graph(graph,
   meta_graph = tf.train.export_meta_graph(
       graph_def=graph.as_graph_def(), graph=graph)
   optimized_graph = tf_optimizer.OptimizeGraph(
-      rewriter_config, meta_graph, cluster=get_cluster())
+      config, meta_graph, cluster=get_cluster())
 
   unsupported = validate(optimized_graph.node, skip_op_check,
                          strip_debug_ops)


### PR DESCRIPTION
This would allow some users to install tfjs converter, apparently 1.12 is not available for certain python versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/337)
<!-- Reviewable:end -->
