### PR TITLE
remove the session_bundle and tf_frozen_model as valid input_format entries

### DIFF
--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -238,8 +238,8 @@ def setup_arugments():
       required=False,
       default='tf_saved_model',
       choices=set(['keras', 'keras_saved_model',
-                   'tf_saved_model', 'tf_session_bundle', 'tf_frozen_model',
-                   'tf_hub', 'tfjs_layers_model', 'tensorflowjs']),
+                   'tf_saved_model', 'tf_hub', 'tfjs_layers_model',
+                   'tensorflowjs']),
       help='Input format. '
       'For "keras", the input path can be one of the two following formats:\n'
       '  - A topology+weights combined HDF5 (e.g., generated with'


### PR DESCRIPTION
fix https://github.com/tensorflow/tfjs/issues/1409

session_bundle and frozen_graph are listed as valid input_format by mistake, which generated opaque error message.

By removing them, the error message is much cleaner.

```
15:47 $ tensorflowjs_converter --input_format=session_bundle ~/Downloads/ssdlite_mobilenet_v2_coco_2018_05_09/ ~/tmp/web_model
usage: TensorFlow.js model converters. [-h]
                                       [--input_format {tfjs_layers_model,tensorflowjs,tf_hub,keras_saved_model,keras,tf_saved_model}]
                                       [--output_format {keras,tfjs_layers_model,tensorflowjs,tfjs_graph_model}]
                                       [--signature_name SIGNATURE_NAME]
                                       [--saved_model_tags SAVED_MODEL_TAGS]
                                       [--quantization_bytes {1,2}]
                                       [--split_weights_by_layer] [--version]
                                       [--skip_op_check SKIP_OP_CHECK]
                                       [--strip_debug_ops STRIP_DEBUG_OPS]
                                       [input_path] [output_path]
TensorFlow.js model converters.: error: argument --input_format: invalid choice: 'session_bundle' (choose from 'tfjs_layers_model', 'tensorflowjs', 'tf_hub', 'keras_saved_model', 'keras', 'tf_saved_model')
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/341)
<!-- Reviewable:end -->
