### PR TITLE
Support tfjs_layers_model2tfjs_layers_model sharding & quantization

### DIFF
--- a/python/tensorflowjs/converters/converter.py
+++ b/python/tensorflowjs/converters/converter.py
@@ -35,7 +35,8 @@ from tensorflowjs.converters import tf_saved_model_conversion_v2
 
 def dispatch_keras_h5_to_tensorflowjs_conversion(
     h5_path, output_dir=None, quantization_dtype=None,
-    split_weights_by_layer=False):
+    split_weights_by_layer=False,
+    weight_shard_size_bytes=1024 * 1024 * 4):
   """Converts a Keras HDF5 saved-model file to TensorFlow.js format.
 
   Auto-detects saved_model versus weights-only and generates the correct
@@ -55,6 +56,8 @@ def dispatch_keras_h5_to_tensorflowjs_conversion(
     split_weights_by_layer: Whether to split the weights into separate weight
       groups (corresponding to separate binary weight files) layer by layer
       (Default: `False`).
+    weight_shard_size_bytes: Shard size (in bytes) of the weight files.
+      The size of each weight file will be <= this value.
 
   Returns:
     (model_json, groups)
@@ -86,7 +89,8 @@ def dispatch_keras_h5_to_tensorflowjs_conversion(
     if not os.path.isdir(output_dir):
       os.makedirs(output_dir)
     conversion.write_artifacts(
-        model_json, groups, output_dir, quantization_dtype)
+        model_json, groups, output_dir, quantization_dtype,
+        weight_shard_size_bytes=weight_shard_size_bytes)
 
   return model_json, groups
 
@@ -133,7 +137,7 @@ def dispatch_keras_saved_model_to_tensorflowjs_conversion(
 
 
 def dispatch_tensorflowjs_to_keras_h5_conversion(config_json_path, h5_path):
-  """Converts a Keras Model from tensorflowjs format to H5.
+  """Converts a TensorFlow.js Layers model format to Keras H5.
 
   Args:
     config_json_path: Path to the JSON file that includes the model's
@@ -168,7 +172,60 @@ def dispatch_tensorflowjs_to_keras_h5_conversion(config_json_path, h5_path):
   with tf.Graph().as_default(), tf.compat.v1.Session():
     model = keras_tfjs_loader.load_keras_model(config_json_path)
     model.save(h5_path)
-    print('Saved Keras model to HDF5 file: %s' % h5_path)
+
+
+def dispatch_tensorflowjs_to_tensorflowjs_conversion(
+    config_json_path,
+    output_dir_path,
+    weight_shard_size_bytes=1024 * 1024 * 4):
+  """Converts a Keras Model from tensorflowjs format to H5.
+
+  Args:
+    config_json_path: Path to the JSON file that includes the model's
+      topology and weights manifest, in tensorflowjs format.
+    output_dir_path: Path to the directory in which the converted
+      model will be saved. This includes the model.json file and the
+      possibly sharded binary weight files. The directory will be
+      created if the path doesn't exist.
+
+  Raises:
+    ValueError, if `config_json_path` is not a path to a valid JSON
+      file, or if h5_path points to an existing directory.
+    ValueError, if `output_dir_path` exists and is a file (instead of
+      a directory).
+  """
+  if os.path.isdir(config_json_path):
+    raise ValueError(
+        'For input_type=tensorflowjs & output_format=keras, '
+        'the input path should be a model.json '
+        'file, but received a directory.')
+  # TODO(cais): Assert output_dir_path doesn't exist or is the path to
+  # a directory (not a file).
+
+  # Verify that config_json_path points to a JSON file.
+  with open(config_json_path, 'rt') as f:
+    try:
+      json.load(f)
+    except (ValueError, IOError):
+      raise ValueError(
+          'For input_type=tensorflowjs & output_format=keras, '
+          'the input path is expected to contain valid JSON content, '
+          'but cannot read valid JSON content from %s.' % config_json_path)
+
+  temp_h5_path = tempfile.mktemp(suffix='.h5')
+  with tf.Graph().as_default(), tf.compat.v1.Session():
+    model = keras_tfjs_loader.load_keras_model(config_json_path)
+    model.save(temp_h5_path)
+    dispatch_tensorflowjs_to_keras_h5_conversion(config_json_path, temp_h5_path)
+
+  with tf.Graph().as_default(), tf.compat.v1.Session():
+    dispatch_keras_h5_to_tensorflowjs_conversion(
+        temp_h5_path, output_dir_path,
+        weight_shard_size_bytes=weight_shard_size_bytes)
+    # TODO(cais): Support weight quantization.
+
+  # Clean up the temporary H5 file.
+  os.remove(temp_h5_path)
 
 
 def _standardize_input_output_formats(input_format, output_format):
@@ -303,6 +360,11 @@ def setup_arugments():
       type=bool,
       default=True,
       help='Strip debug ops (Print, Assert, CheckNumerics) from graph.')
+  parser.add_argument(
+      '--weight_shard_size_bytes',
+      type=int,
+      default=1024 * 1024 * 4,
+      help='Shard size (in bytes) of the weight files.')
   return parser.parse_args()
 
 
@@ -366,6 +428,13 @@ def main():
         output_format == 'keras'):
     dispatch_tensorflowjs_to_keras_h5_conversion(FLAGS.input_path,
                                                  FLAGS.output_path)
+  elif (input_format == 'tfjs_layers_model' and
+        output_format == 'tfjs_layers_model'):
+    dispatch_tensorflowjs_to_tensorflowjs_conversion(
+        FLAGS.input_path, FLAGS.output_path,
+        weight_shard_size_bytes=FLAGS.weight_shard_size_bytes)
+    # TODO(cais): Add quantization support.
+
 
   else:
     raise ValueError(

--- a/python/tensorflowjs/converters/converter_test.py
+++ b/python/tensorflowjs/converters/converter_test.py
@@ -554,7 +554,8 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       with open(sharded_model_path, 'wt') as f:
         # Create a fie at the path to elicit the error.
         f.write('hello')
-      with self.assertRaisesRegexp(ValueError, r'already exists as a file'):
+      with self.assertRaisesRegexp(  # pylint: disable=deprecated-method
+          ValueError, r'already exists as a file'):
         converter.dispatch_tensorflowjs_to_tensorflowjs_conversion(
             os.path.join(tfjs_output_dir, 'model.json'), sharded_model_path)
 

--- a/python/tensorflowjs/converters/converter_test.py
+++ b/python/tensorflowjs/converters/converter_test.py
@@ -468,6 +468,96 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
           w.size * bytes_per_num for w in model.get_weights())
       self.assertEqual(weight_file_bytes, model_weight_bytes)
 
+  def testConvertTfjsLayersModelToShardedWeights(self):
+    with tf.Graph().as_default(), tf.compat.v1.Session():
+      model = self._createSimpleSequentialModel()
+      weights = model.get_weights()
+      total_weight_bytes = sum(np.size(w) for w in weights) * 4
+
+      # Save the keras model to a .h5 file.
+      h5_path = os.path.join(self._tmp_dir, 'model.h5')
+      model.save(h5_path)
+
+      # Convert the keras SavedModel to tfjs format.
+      tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
+      converter.dispatch_keras_h5_to_tensorflowjs_conversion(
+          h5_path, tfjs_output_dir)
+
+      weight_shard_size_bytes = int(total_weight_bytes * 0.3)
+      # Due to the shard size, there ought to be 4 shards after conversion.
+
+      # Convert the tfjs model to another tfjs model, with a specified weight
+      # shard size.
+      sharded_model_path = os.path.join(self._tmp_dir, 'sharded_model')
+      converter.dispatch_tensorflowjs_to_tensorflowjs_conversion(
+          os.path.join(tfjs_output_dir, 'model.json'), sharded_model_path,
+          weight_shard_size_bytes=weight_shard_size_bytes)
+
+      # Check the number of sharded files and their sizes.
+      weight_files = sorted(
+          glob.glob(os.path.join(sharded_model_path, 'group*.bin')))
+      self.assertEqual(len(weight_files), 4)
+      weight_file_sizes = [os.path.getsize(f) for f in weight_files]
+      self.assertEqual(sum(weight_file_sizes), total_weight_bytes)
+      self.assertEqual(weight_file_sizes[0], weight_file_sizes[1])
+      self.assertEqual(weight_file_sizes[0], weight_file_sizes[2])
+      self.assertLess(weight_file_sizes[3], weight_file_sizes[0])
+
+  def testConvertTfjsLayersModelWithShardSizeGreaterThanTotalWeightSize(self):
+    with tf.Graph().as_default(), tf.compat.v1.Session():
+      model = self._createSimpleSequentialModel()
+      weights = model.get_weights()
+      total_weight_bytes = sum(np.size(w) for w in weights) * 4
+
+      # Save the keras model to a .h5 file.
+      h5_path = os.path.join(self._tmp_dir, 'model.h5')
+      model.save(h5_path)
+
+      # Convert the keras SavedModel to tfjs format.
+      tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
+      converter.dispatch_keras_h5_to_tensorflowjs_conversion(
+          h5_path, tfjs_output_dir)
+
+      weight_shard_size_bytes = int(total_weight_bytes * 2)
+      # Due to the shard size, there ought to be 1 shard after conversion.
+
+      # Convert the tfjs model to another tfjs model, with a specified weight
+      # shard size.
+      sharded_model_path = os.path.join(self._tmp_dir, 'sharded_model')
+      converter.dispatch_tensorflowjs_to_tensorflowjs_conversion(
+          os.path.join(tfjs_output_dir, 'model.json'), sharded_model_path,
+          weight_shard_size_bytes=weight_shard_size_bytes)
+
+      # Check the number of sharded files and their sizes.
+      weight_files = sorted(
+          glob.glob(os.path.join(sharded_model_path, 'group*.bin')))
+      self.assertEqual(len(weight_files), 1)
+      weight_file_sizes = [os.path.getsize(f) for f in weight_files]
+      self.assertEqual(sum(weight_file_sizes), total_weight_bytes)
+
+  def testTfjsLayer2TfjsLayersConversionWithExistingFilePathFails(self):
+    with tf.Graph().as_default(), tf.compat.v1.Session():
+      model = self._createSimpleSequentialModel()
+
+      # Save the keras model to a .h5 file.
+      h5_path = os.path.join(self._tmp_dir, 'model.h5')
+      model.save(h5_path)
+
+      # Convert the keras SavedModel to tfjs format.
+      tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
+      converter.dispatch_keras_h5_to_tensorflowjs_conversion(
+          h5_path, tfjs_output_dir)
+
+      # Convert the tfjs model to another tfjs model, with a specified weight
+      # shard size.
+      sharded_model_path = os.path.join(self._tmp_dir, 'sharded_model')
+      with open(sharded_model_path, 'wt') as f:
+        # Create a fie at the path to elicit the error.
+        f.write('hello')
+      with self.assertRaisesRegexp(ValueError, r'already exists as a file'):
+        converter.dispatch_tensorflowjs_to_tensorflowjs_conversion(
+            os.path.join(tfjs_output_dir, 'model.json'), sharded_model_path)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/python/tensorflowjs/converters/converter_test.py
+++ b/python/tensorflowjs/converters/converter_test.py
@@ -580,7 +580,8 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       sharded_model_path = os.path.join(self._tmp_dir, 'sharded_model')
       converter.dispatch_tensorflowjs_to_tensorflowjs_conversion(
           os.path.join(tfjs_output_dir, 'model.json'), sharded_model_path,
-          quantization_dtype=np.uint16)
+          quantization_dtype=np.uint16,
+          weight_shard_size_bytes=weight_shard_size_bytes)
 
       # Check the number of quantized files and their sizes.
       weight_files = sorted(
@@ -588,8 +589,8 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       self.assertEqual(len(weight_files), 1)
       weight_file_size = os.path.getsize(weight_files[0])
 
-      # The size of the saved weight file should reflect the result of the uint16
-      # quantization.
+      # The size of the saved weight file should reflect the result of the
+      # uint16 quantization.
       self.assertEqual(weight_file_size, total_weight_bytes / 2)
 
   def testConvertTfjsLayersModelWithUint8Quantization(self):
@@ -614,7 +615,8 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       sharded_model_path = os.path.join(self._tmp_dir, 'sharded_model')
       converter.dispatch_tensorflowjs_to_tensorflowjs_conversion(
           os.path.join(tfjs_output_dir, 'model.json'), sharded_model_path,
-          quantization_dtype=np.uint8)
+          quantization_dtype=np.uint8,
+          weight_shard_size_bytes=weight_shard_size_bytes)
 
       # Check the number of quantized files and their sizes.
       weight_files = sorted(
@@ -622,8 +624,8 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       self.assertEqual(len(weight_files), 1)
       weight_file_size = os.path.getsize(weight_files[0])
 
-      # The size of the saved weight file should reflect the result of the uint16
-      # quantization.
+      # The size of the saved weight file should reflect the result of the
+      # uint16 quantization.
       self.assertEqual(weight_file_size, total_weight_bytes / 4)
 
 

--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -334,7 +334,9 @@ def _assert_weight_groups_valid(weight_groups):
 def _assert_shard_size_bytes_valid(shard_size_bytes):
   if shard_size_bytes < 0:
     raise ValueError(
-        'shard_size_bytes must be greater than 0, but got ' + shard_size_bytes)
+        'shard_size_bytes must be greater than 0, but got %s' %
+        shard_size_bytes)
   if not isinstance(shard_size_bytes, int):
     raise ValueError(
-        'shard_size_bytes must be an integer, but got ' + shard_size_bytes)
+        'shard_size_bytes must be an integer, but got %s' %
+        shard_size_bytes)

--- a/python/test_pip_package.py
+++ b/python/test_pip_package.py
@@ -787,6 +787,52 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
       new_y = new_model.predict(x)
       self.assertAllClose(new_y, y)
 
+  def testConvertTfjsLayersModelWithQuantization(self):
+    with tf.Graph().as_default(), tf.compat.v1.Session():
+      x = np.random.randn(8, 10)
+
+      # 1. Run the model.predict(), store the result. Then saved the model
+      #    as a SavedModel.
+      model = self._createNestedSequentialModel()
+      y = model.predict(x)
+
+      weights = model.get_weights()
+      total_weight_bytes = sum(np.size(w) for w in weights) * 4
+
+      keras.experimental.export_saved_model(model, self._tmp_dir)
+
+      # 2. Convert the keras saved model to tfjs_layers_model format.
+      tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
+      # Implicit value of --output_format: tfjs_layers_model
+      process = subprocess.Popen([
+          'tensorflowjs_converter', '--input_format', 'keras_saved_model',
+          self._tmp_dir, tfjs_output_dir
+      ])
+      process.communicate()
+      self.assertEqual(0, process.returncode)
+
+      # 3. Convert the tfjs_layers_model to another tfjs_layers_model,
+      #    with uint16 quantization.
+      weight_shard_size_bytes = int(total_weight_bytes * 0.3)
+      # Due to the shard size, there ought to be 4 shards after conversion.
+      sharded_model_dir = os.path.join(self._tmp_dir, 'tfjs_sharded')
+      process = subprocess.Popen([
+          'tensorflowjs_converter', '--input_format', 'tfjs_layers_model',
+          '--output_format', 'tfjs_layers_model',
+          '--quantization_bytes', '2',
+          os.path.join(tfjs_output_dir, 'model.json'), sharded_model_dir
+      ])
+      process.communicate()
+      self.assertEqual(0, process.returncode)
+
+      # 4. Check the quantized weight file and its size.
+      weight_files = sorted(
+          glob.glob(os.path.join(sharded_model_dir, 'group*.bin')))
+      self.assertEqual(len(weight_files), 1)
+      weight_file_size = os.path.getsize(weight_files[0])
+      # The size of the weight file should reflect the uint16 quantization.
+      self.assertEqual(weight_file_size, total_weight_bytes // 2)
+
 
 if __name__ == '__main__':
   tf.test.main()

--- a/python/test_pip_package.py
+++ b/python/test_pip_package.py
@@ -723,6 +723,70 @@ class ConvertTfKerasSavedModelTest(tf.test.TestCase):
           b'Expected path to point to an HDF5 file, '
           b'but it points to a directory', tf.compat.as_bytes(stderr))
 
+  def testConvertTfjsLayersModelIntoShardedWeights(self):
+    with tf.Graph().as_default(), tf.compat.v1.Session():
+      x = np.random.randn(8, 10)
+
+      # 1. Run the model.predict(), store the result. Then saved the model
+      #    as a SavedModel.
+      model = self._createNestedSequentialModel()
+      y = model.predict(x)
+
+      weights = model.get_weights()
+      total_weight_bytes = sum(np.size(w) for w in weights) * 4
+
+      keras.experimental.export_saved_model(model, self._tmp_dir)
+
+      # 2. Convert the keras saved model to tfjs_layers_model format.
+      tfjs_output_dir = os.path.join(self._tmp_dir, 'tfjs')
+      # Implicit value of --output_format: tfjs_layers_model
+      process = subprocess.Popen([
+          'tensorflowjs_converter', '--input_format', 'keras_saved_model',
+          self._tmp_dir, tfjs_output_dir
+      ])
+      process.communicate()
+      self.assertEqual(0, process.returncode)
+
+      # 3. Convert the tfjs_layers_model to another tfjs_layers_model,
+      #    with sharded weights.
+      weight_shard_size_bytes = int(total_weight_bytes * 0.3)
+      # Due to the shard size, there ought to be 4 shards after conversion.
+      sharded_model_dir = os.path.join(self._tmp_dir, 'tfjs_sharded')
+      process = subprocess.Popen([
+          'tensorflowjs_converter', '--input_format', 'tfjs_layers_model',
+          '--output_format', 'tfjs_layers_model',
+          '--weight_shard_size_bytes', str(weight_shard_size_bytes),
+          os.path.join(tfjs_output_dir, 'model.json'), sharded_model_dir
+      ])
+      process.communicate()
+      self.assertEqual(0, process.returncode)
+
+      # 4. Check the sharded weight files and their sizes.
+      weight_files = sorted(
+          glob.glob(os.path.join(sharded_model_dir, 'group*.bin')))
+      self.assertEqual(len(weight_files), 4)
+      weight_file_sizes = [os.path.getsize(f) for f in weight_files]
+      self.assertEqual(sum(weight_file_sizes), total_weight_bytes)
+      self.assertEqual(weight_file_sizes[0], weight_file_sizes[1])
+      self.assertEqual(weight_file_sizes[0], weight_file_sizes[2])
+      self.assertLess(weight_file_sizes[3], weight_file_sizes[0])
+
+      # 5. Convert the sharded tfjs_layers_model back into a keras h5 file.
+      new_h5_path = os.path.join(self._tmp_dir, 'new_h5.h5')
+      process = subprocess.Popen([
+          'tensorflowjs_converter', '--input_format', 'tfjs_layers_model',
+          os.path.join(sharded_model_dir, 'model.json'), new_h5_path
+      ])
+      process.communicate()
+      self.assertEqual(0, process.returncode)
+
+    with tf.Graph().as_default(), tf.compat.v1.Session():
+      # 6. Load the keras model and check the predict() output is close to
+      #    before.
+      new_model = keras.models.load_model(new_h5_path)
+      new_y = new_model.predict(x)
+      self.assertAllClose(new_y, y)
+
 
 if __name__ == '__main__':
   tf.test.main()


### PR DESCRIPTION
Example for new command line for weight sharding:

```sh
tensorflowjs_converter \
    --input_format tfjs_layers_model \
    --output_format tfjs_layers_model \
    --weight_shard_size_bytes 2000000 \
    model/model.json
    sharded_model/
```

Example command line for weight quantization:

```sh
tensorflowjs_converter \
    --input_format tfjs_layers_model \
    --output_format tfjs_layers_model \
    --quantization_bytes 2 \
    model/model.json
    quantized_model/
```

FEATURE

Fixes https://github.com/tensorflow/tfjs/issues/1459

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/346)
<!-- Reviewable:end -->
