### PR TITLE
use tf 2.0 pip instead of nightly build

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,5 +2,5 @@ h5py==2.8.0
 keras==2.2.4
 numpy==1.15.1
 six==1.11.0
-tf-nightly-2.0-preview>=2.0.0.dev20190304
+tensorflow>=2.0.0a0
 tensorflow-hub==0.3.0

--- a/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
+++ b/python/tensorflowjs/converters/tf_saved_model_conversion_v2_test.py
@@ -187,7 +187,11 @@ class ConvertTest(unittest.TestCase):
 
     weights = [{
         'paths': ['group1-shard1of1.bin'],
-        'weights': [{'dtype': 'float32',
+        'weights': [{'name': 'statefulpartitionedcall_args_1',
+                     'shape': [], 'dtype': 'float32'},
+                    {'name': 'statefulpartitionedcall_args_2',
+                     'shape': [], 'dtype': 'float32'},
+                    {'dtype': 'float32',
                      'name': 'StatefulPartitionedCall/mul',
                      'shape': []}]}]
 
@@ -240,6 +244,9 @@ class ConvertTest(unittest.TestCase):
     weights = [{
         'paths': ['group1-shard1of1.bin'],
         'weights': [{'dtype': 'float32',
+                     'name': 'statefulpartitionedcall_args_1',
+                     'shape': [2, 2]},
+                    {'dtype': 'float32',
                      'name': 'StatefulPartitionedCall/MatrixDiag',
                      'shape': [2, 2, 2]}]}]
     tfjs_path = os.path.join(self._tmp_dir, SAVED_MODEL_DIR)

--- a/python/test_pip_package.py
+++ b/python/test_pip_package.py
@@ -456,6 +456,16 @@ class APIAndShellTest(tf.test.TestCase):
           'dtype': 'float32',
           'shape': [],
           'name': 'StatefulPartitionedCall/mul'
+        },
+        {
+          'dtype': 'float32',
+          'shape': [],
+          'name': 'statefulpartitionedcall_args_2'
+        },
+        {
+          'dtype': 'float32',
+          'shape': [],
+          'name': 'statefulpartitionedcall_args_1'
         }]
     }]
 


### PR DESCRIPTION
This is a more stable pip build for TF 2.0 instead of the nightly.
It will be updated roughly every two weeks and maintained after alpha too.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/354)
<!-- Reviewable:end -->
