### PR TITLE
Update core dependency to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   },
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@tensorflow/tfjs-core": "1.1.0"
+    "@tensorflow/tfjs-core": "1.1.2"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "1.1.0",
+    "@tensorflow/tfjs-core": "1.1.2",
     "@types/jasmine": "~2.8.6",
     "@types/long": "~3.0.32",
     "@types/node-fetch": "1.6.9",

--- a/src/executor/graph_executor_test.ts
+++ b/src/executor/graph_executor_test.ts
@@ -127,26 +127,27 @@ describe('GraphExecutor', () => {
 
     describe('graph level', () => {
       describe('execute', () => {
-        it('should execute the op', () => {
+        it('should execute the op', async () => {
           const inputTensor = tfc.scalar(1);
 
           const result = executor.execute({input: [inputTensor]});
-          tfc.test_util.expectArraysClose(result['output'], [5.0]);
+          tfc.test_util.expectArraysClose(await result['output'].data(), [5.0]);
         });
 
-        it('should allow output intermediate nodes', () => {
+        it('should allow output intermediate nodes', async () => {
           const inputTensor = tfc.scalar(1);
           const result = executor.execute(
               {input: [inputTensor]}, false, ['output', 'intermediate']);
-          tfc.test_util.expectArraysClose(result['intermediate'], [3.0]);
-          tfc.test_util.expectArraysClose(result['output'], [5.0]);
+          tfc.test_util.expectArraysClose(
+              await result['intermediate'].data(), [3.0]);
+          tfc.test_util.expectArraysClose(await result['output'].data(), [5.0]);
         });
 
-        it('should allow feed intermediate nodes', () => {
+        it('should allow feed intermediate nodes', async () => {
           const intermediateTensor = tfc.scalar(1);
           const result =
               executor.execute({intermediate: [intermediateTensor]}, false);
-          tfc.test_util.expectArraysClose(result['output'], [3.0]);
+          tfc.test_util.expectArraysClose(await result['output'].data(), [3.0]);
         });
 
         describe('strict input check', () => {
@@ -370,7 +371,8 @@ describe('GraphExecutor', () => {
 
           const result =
               await executor.executeAsync({input: [inputTensor]}, 'output:1');
-          tfc.test_util.expectArraysClose(result['output:1'], [0.57735]);
+          tfc.test_util.expectArraysClose(
+              await result['output:1'].data(), [0.57735]);
           done();
         });
 
@@ -378,7 +380,8 @@ describe('GraphExecutor', () => {
           const inputTensor = tfc.scalar(1);
           const result = await executor.executeAsync(
               {input: [inputTensor]}, ['intermediate']);
-          tfc.test_util.expectArraysClose(result['intermediate'], [3.0]);
+          tfc.test_util.expectArraysClose(
+              await result['intermediate'].data(), [3.0]);
           done();
         });
 
@@ -389,10 +392,12 @@ describe('GraphExecutor', () => {
 
              const result = await executor.executeAsync(
                  {intermediate: [inputTensor]}, 'output:1');
-             tfc.test_util.expectArraysClose(result['output:1'], [1]);
+             tfc.test_util.expectArraysClose(
+                 await result['output:1'].data(), [1]);
              const result2 = await executor.executeAsync(
                  {intermediate: [inputTensor]}, 'output:1');
-             tfc.test_util.expectArraysClose(result2['output:1'], [1]);
+             tfc.test_util.expectArraysClose(
+                 await result2['output:1'].data(), [1]);
 
              done();
            });

--- a/src/executor/graph_model_test.ts
+++ b/src/executor/graph_model_test.ts
@@ -232,7 +232,7 @@ describe('Model', () => {
         await model.load();
         const input = tfc.tensor2d([1, 1], [2, 1], 'int32');
         const output = model.execute({'Add1': input}) as tfc.Tensor;
-        tfc.test_util.expectArraysClose(output, [2, 2]);
+        tfc.test_util.expectArraysClose(await output.data(), [2, 2]);
       });
     });
 

--- a/src/executor/tensor_array_test.ts
+++ b/src/executor/tensor_array_test.ts
@@ -133,16 +133,16 @@ describe('TensorArray', () => {
       tensorArray.writeMany([0, 1], [tensor, tensor2]);
     });
 
-    it('should return default packed tensors', () => {
+    it('should return default packed tensors', async () => {
       const gathered = tensorArray.gather();
       expect(gathered.shape).toEqual([2, 1, 1]);
-      test_util.expectArraysClose(gathered, [1, 2]);
+      test_util.expectArraysClose(await gathered.data(), [1, 2]);
     });
 
-    it('should return packed tensors when indices is specified', () => {
+    it('should return packed tensors when indices is specified', async () => {
       const gathered = tensorArray.gather([1, 0]);
       expect(gathered.shape).toEqual([2, 1, 1]);
-      test_util.expectArraysClose(gathered, [2, 1]);
+      test_util.expectArraysClose(await gathered.data(), [2, 1]);
     });
     it('should fail if dtype is not matched', () => {
       expect(() => tensorArray.gather([0, 1], 'float32')).toThrow();
@@ -159,10 +159,10 @@ describe('TensorArray', () => {
       tensorArray.writeMany([0, 1], [tensor, tensor2]);
     });
 
-    it('should return default concat tensors', () => {
+    it('should return default concat tensors', async () => {
       const concat = tensorArray.concat();
       expect(concat.shape).toEqual([2, 1]);
-      test_util.expectArraysClose(concat, [1, 2]);
+      test_util.expectArraysClose(await concat.data(), [1, 2]);
     });
 
     it('should fail if dtype is not matched', () => {

--- a/src/operations/executors/arithmetic_executor_test.ts
+++ b/src/operations/executors/arithmetic_executor_test.ts
@@ -54,7 +54,7 @@ describe('arithmetic', () => {
             expect(spy).toHaveBeenCalledWith(input1[0], input2[0]);
           });
         }));
-    it('AddN', () => {
+    it('AddN', async () => {
       const spy = spyOn(tfc, 'addN').and.callThrough();
       node.op = 'AddN';
       node.inputParams = {tensors: createTensorsAttr(0, 0)};
@@ -64,7 +64,7 @@ describe('arithmetic', () => {
       expect(spy).toHaveBeenCalledWith([input1[0], input2[0], input3[0]]);
       expect(res[0].dtype).toBe('float32');
       expect(res[0].shape).toEqual([]);
-      tfc.test_util.expectArraysClose(res[0], [6]);
+      tfc.test_util.expectArraysClose(await res[0].data(), [6]);
     });
   });
 });

--- a/src/operations/executors/control_executor_test.ts
+++ b/src/operations/executors/control_executor_test.ts
@@ -55,7 +55,8 @@ describe('control', () => {
         const pred = [tfc.scalar(true)];
         const result = await executeOp(node, {pred, input1}, context);
         expect(result[0]).toBeUndefined();
-        test_util.expectArraysEqual(result[1], input1[0]);
+        test_util.expectArraysEqual(
+            await result[1].array(), await input1[0].array());
       });
       it('should set the output condition is false', async () => {
         node.op = 'Switch';
@@ -64,7 +65,8 @@ describe('control', () => {
 
         const pred = [tfc.scalar(false)];
         const result = await executeOp(node, {pred, input1}, context);
-        test_util.expectArraysEqual(result[0], input1[0]);
+        test_util.expectArraysEqual(
+            await result[0].array(), await input1[0].array());
         expect(result[1]).toBeUndefined();
       });
       it('should match json def', () => {
@@ -81,11 +83,13 @@ describe('control', () => {
 
         const pred = [tfc.scalar(true)];
         test_util.expectArraysEqual(
-            (await executeOp(node, {pred: undefined, input1}, context))[0],
-            input1[0]);
+            await (await executeOp(node, {pred: undefined, input1}, context))[0]
+                .array(),
+            await input1[0].array());
         test_util.expectArraysEqual(
-            (await executeOp(node, {pred, input1: undefined}, context))[0],
-            pred[0]);
+            await (await executeOp(node, {pred, input1: undefined}, context))[0]
+                .array(),
+            await pred[0].array());
       });
       it('should return undefined if no inputs are available', async () => {
         node.op = 'Merge';
@@ -109,7 +113,8 @@ describe('control', () => {
         node.inputNames = ['input1'];
 
         test_util.expectArraysEqual(
-            (await executeOp(node, {input1}, context))[0], input1[0]);
+            await (await executeOp(node, {input1}, context))[0].array(),
+            await input1[0].array());
         expect(context.enterFrame).toHaveBeenCalled();
       });
       it('should match json def', () => {
@@ -127,7 +132,8 @@ describe('control', () => {
         node.inputNames = ['input1'];
 
         test_util.expectArraysEqual(
-            (await executeOp(node, {input1}, context))[0], input1[0]);
+            await (await executeOp(node, {input1}, context))[0].array(),
+            await input1[0].array());
         expect(context.exitFrame).toHaveBeenCalled();
       });
       it('should match json def', () => {
@@ -145,7 +151,8 @@ describe('control', () => {
         node.inputNames = ['input1'];
 
         test_util.expectArraysEqual(
-            (await executeOp(node, {input1}, context))[0], input1[0]);
+            await (await executeOp(node, {input1}, context))[0].array(),
+            await input1[0].array());
         expect(context.nextIteration).toHaveBeenCalled();
       });
       it('should match json def', () => {
@@ -227,7 +234,8 @@ describe('control', () => {
         const input3 = [scalar(0)];
         const read = await executeOp(node, {input1, input2, input3}, context);
 
-        test_util.expectArraysClose(read[0], input4);
+        test_util.expectArraysClose(
+            await read[0].array(), await input4.array());
       });
       it('should match json def', () => {
         node.op = 'TensorArrayReadV3';

--- a/src/operations/executors/graph_executor_test.ts
+++ b/src/operations/executors/graph_executor_test.ts
@@ -64,13 +64,14 @@ describe('graph', () => {
       });
     });
     describe('Identity', () => {
-      it('should return input', () => {
+      it('should return input', async () => {
         node.inputNames = ['input'];
         node.inputParams.x = createTensorAttr(0);
         node.op = 'Identity';
         test_util.expectArraysEqual(
-            (executeOp(node, {input: input1}, context) as tfc.Tensor[])[0],
-            input1[0]);
+            await (executeOp(node, {input: input1}, context) as tfc.Tensor[])[0]
+                .array(),
+            await input1[0].array());
       });
     });
     describe('IdentityN', () => {
@@ -86,14 +87,14 @@ describe('graph', () => {
       });
     });
     describe('Snapshot', () => {
-      it('should return input', () => {
+      it('should return input', async () => {
         node.inputNames = ['input'];
         node.inputParams.x = createTensorAttr(0);
         node.op = 'Snapshot';
         const result =
             (executeOp(node, {input: input1}, context) as tfc.Tensor[])[0];
         expect(result.rank).toEqual(input1[0].rank);
-        test_util.expectArraysClose(result, [1]);
+        test_util.expectArraysClose(await result.data(), [1]);
       });
     });
     describe('Shape', () => {
@@ -169,23 +170,25 @@ describe('graph', () => {
     });
   });
   describe('StopGradient', () => {
-    it('should return input', () => {
+    it('should return input', async () => {
       node.inputNames = ['input'];
       node.inputParams.x = createTensorAttr(0);
       node.op = 'StopGradient';
       test_util.expectArraysClose(
-          (executeOp(node, {input: input1}, context) as tfc.Tensor[])[0],
-          input1[0]);
+          await (executeOp(node, {input: input1}, context) as tfc.Tensor[])[0]
+              .array(),
+          await input1[0].array());
     });
   });
   describe('FakeQuantWithMinMaxVars', () => {
-    it('should return input', () => {
+    it('should return input', async () => {
       node.inputNames = ['input'];
       node.inputParams.x = createTensorAttr(0);
       node.op = 'FakeQuantWithMinMaxVars';
       test_util.expectArraysClose(
-          (executeOp(node, {input: input1}, context) as tfc.Tensor[])[0],
-          input1[0]);
+          await (executeOp(node, {input: input1}, context) as tfc.Tensor[])[0]
+              .array(),
+          await input1[0].array());
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,10 +55,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@tensorflow/tfjs-core@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.1.0.tgz#028c69291e19c328c4c30e18d29b09135c22cb44"
-  integrity sha512-loPpHGVjiyEb+Ixlsj8prQ/r4exekITn7vM4WEyHUouFKx0/CuoB2FQ0m6DSb/6ApvucxTWGGNTRRo4HK4Ma0Q==
+"@tensorflow/tfjs-core@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-1.1.2.tgz#efb8b3688fbff353e51d41a3d832dde8c1bc321d"
+  integrity sha512-xCAUIAh14OFnHt+IQUUZIH/P/jH/EWvewL0Ty6q6USUx4YZ+HvKwNw1G7h/gKki4A31BJ0avD04ylBKc75laGg==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"


### PR DESCRIPTION
Update core dependency to 1.1.2

**Details**
- Fix build errors introduced by change in the signature of `expectArraysEqual/Close` where `Tensor` is not a valid entry anymore, and we want to avoid calling `dataSync() ` in unit tests so we can run unit tests against async-only backends

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/356)
<!-- Reviewable:end -->
