### PR TITLE
Fix bug when forwarding dilations in conv2d to tfjs

### DIFF
--- a/src/operations/executors/convolution_executor.ts
+++ b/src/operations/executors/convolution_executor.ts
@@ -55,7 +55,7 @@ export let executeOp: OpExecutor =
                   tfc.Tensor4D,
               getParamValue('filter', node, tensorMap, context) as tfc.Tensor4D,
               [stride[1], stride[2]], pad as 'valid' | 'same',
-              dataFormat as 'NHWC' | 'NCHW', [dilations[0], dilations[1]])];
+              dataFormat as 'NHWC' | 'NCHW', [dilations[1], dilations[2]])];
         }
         case 'Conv2DBackpropInput':
         case 'Conv2dTranspose': {
@@ -88,7 +88,7 @@ export let executeOp: OpExecutor =
                   tfc.Tensor4D,
               getParamValue('filter', node, tensorMap, context) as tfc.Tensor4D,
               [stride[1], stride[2]], pad as 'valid' | 'same',
-              dataFormat as 'NHWC' | 'NCHW', [dilations[0], dilations[1]])];
+              dataFormat as 'NHWC' | 'NCHW', [dilations[1], dilations[2]])];
         }
 
         case 'AvgPool': {

--- a/src/operations/executors/convolution_executor_test.ts
+++ b/src/operations/executors/convolution_executor_test.ts
@@ -79,7 +79,7 @@ describe('convolution', () => {
         node.attrParams['strides'] = createNumericArrayAttr([1, 2, 2, 1]);
         node.attrParams['pad'] = createStrAttr('same');
         node.attrParams['dataFormat'] = createStrAttr('NHWC');
-        node.attrParams['dilations'] = createNumericArrayAttr([2, 2]);
+        node.attrParams['dilations'] = createNumericArrayAttr([1, 2, 2, 1]);
 
         const input1 = [tfc.scalar(1.0)];
         const input2 = [tfc.scalar(1.0)];
@@ -144,7 +144,7 @@ describe('convolution', () => {
         node.attrParams['strides'] = createNumericArrayAttr([1, 2, 2, 1]);
         node.attrParams['pad'] = createStrAttr('same');
         node.attrParams['dataFormat'] = createStrAttr('NHWC');
-        node.attrParams['dilations'] = createNumericArrayAttr([2, 2]);
+        node.attrParams['dilations'] = createNumericArrayAttr([1, 2, 2, 1]);
         const input1 = [tfc.scalar(1.0)];
         const input2 = [tfc.scalar(1.0)];
         node.inputNames = ['input1', 'input2'];


### PR DESCRIPTION
The SavedModel format encodes the `dilations` attribute in `Conv2D` as 4 numbers. We need to forward the 2nd and 3rd number to tfjs, but we were incorrectly forwarding the first and second. Same for `depthwiseConv2D`.

Fixes https://github.com/tensorflow/tfjs/issues/1587

This came up in the new PoseNet ResNet50 models where the model gives wrong output:
```
input tensor shape: [1, 69, 69, 256]
filter: [3, 3, 256, 256]
appl a conv2d with stride=[1, 1, 1, 1] dilation = [1, 2, 2, 1] padding = "valid"
Gives output shape: [1, **67**, 65, 256]
Should give output shape: [1, 65, 65, 256]
```

cc @tylerzhu-github

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/363)
<!-- Reviewable:end -->
