### PR TITLE
EncodeBase64 and DecodeBase64 ops

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -263,6 +263,7 @@
 
 |Tensorflow Op Name|Tensorflow.js Op Name|
 |---|---|
+|DecodeBase64|decodeBase64|
 |EncodeBase64|encodeBase64|
 
 ## Tensors - Transformations

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -259,6 +259,12 @@
 |Not mapped|ifft|
 |Not mapped|rfft|
 
+## Operations - Strings
+
+|Tensorflow Op Name|Tensorflow.js Op Name|
+|---|---|
+|EncodeBase64|encodeBase64|
+
 ## Tensors - Transformations
 
 |Tensorflow Op Name|Tensorflow.js Op Name|

--- a/src/operations/executors/string_executor.ts
+++ b/src/operations/executors/string_executor.ts
@@ -27,6 +27,11 @@ export let executeOp: InternalOpExecutor =
     (node: Node, tensorMap: NamedTensorsMap,
      context: ExecutionContext): tfc.Tensor[] => {
       switch (node.op) {
+        case 'DecodeBase64': {
+          const input =
+              getParamValue('str', node, tensorMap, context) as tfc.Tensor;
+          return [tfc.decodeBase64(input)];
+        }
         case 'EncodeBase64': {
           const input =
               getParamValue('str', node, tensorMap, context) as tfc.Tensor;

--- a/src/operations/executors/string_executor.ts
+++ b/src/operations/executors/string_executor.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tfc from '@tensorflow/tfjs-core';
+
+import {NamedTensorsMap} from '../../data/types';
+import {ExecutionContext} from '../../executor/execution_context';
+import {InternalOpExecutor, Node} from '../types';
+
+import {getParamValue} from './utils';
+
+export let executeOp: InternalOpExecutor =
+    (node: Node, tensorMap: NamedTensorsMap,
+     context: ExecutionContext): tfc.Tensor[] => {
+      switch (node.op) {
+        case 'EncodeBase64': {
+          const input =
+              getParamValue('str', node, tensorMap, context) as tfc.Tensor;
+          const pad = getParamValue('pad', node, tensorMap, context) as boolean;
+          return [tfc.encodeBase64(input, pad)];
+        }
+        default:
+          throw TypeError(`Node type ${node.op} is not implemented`);
+      }
+    };
+
+export const CATEGORY = 'string';

--- a/src/operations/executors/string_executor_test.ts
+++ b/src/operations/executors/string_executor_test.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+import * as tfc from '@tensorflow/tfjs-core';
+
+import {ExecutionContext} from '../../executor/execution_context';
+import {Node} from '../types';
+
+import {executeOp} from './string_executor';
+// tslint:disable-next-line:max-line-length
+import {createBoolAttr, createTensorAttr} from './test_helper';
+
+describe('string', () => {
+  let node: Node;
+  const input1 = [tfc.tensor(['a'], [1], 'string')];
+  const context = new ExecutionContext({}, {});
+
+  beforeEach(() => {
+    node = {
+      name: 'test',
+      op: '',
+      category: 'string',
+      inputNames: ['input1'],
+      inputs: [],
+      inputParams: {str: createTensorAttr(0)},
+      attrParams: {},
+      children: []
+    };
+  });
+
+  describe('executeOp', () => {
+    describe('EncodeBase64', () => {
+      it('should call tfc.encodeBase64', () => {
+        spyOn(tfc, 'encodeBase64');
+        node.op = 'EncodeBase64';
+        node.attrParams.pad = createBoolAttr(true);
+        executeOp(node, {input1}, context);
+
+        expect(tfc.encodeBase64).toHaveBeenCalledWith(input1[0], true);
+      });
+    });
+  });
+});

--- a/src/operations/executors/string_executor_test.ts
+++ b/src/operations/executors/string_executor_test.ts
@@ -42,6 +42,14 @@ describe('string', () => {
   });
 
   describe('executeOp', () => {
+    describe('DecodeBase64', () => {
+      it('should call tfc.decodeBase64', () => {
+        spyOn(tfc, 'decodeBase64');
+        node.op = 'DecodeBase64';
+        executeOp(node, {input1}, context);
+        expect(tfc.decodeBase64).toHaveBeenCalledWith(input1[0]);
+      });
+    });
     describe('EncodeBase64', () => {
       it('should call tfc.encodeBase64', () => {
         spyOn(tfc, 'encodeBase64');

--- a/src/operations/op_list/string.ts
+++ b/src/operations/op_list/string.ts
@@ -1,0 +1,27 @@
+import {OpMapper} from '../types';
+
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+export const json: OpMapper[] = [
+  {
+    'tfOpName': 'EncodeBase64',
+    'category': 'string',
+    'inputs': [{'start': 0, 'name': 'input', 'type': 'tensor'}],
+    'attrs': [{'tfName': 'pad', 'name': 'pad', 'type': 'bool'}]
+  }
+];

--- a/src/operations/op_list/string.ts
+++ b/src/operations/op_list/string.ts
@@ -19,6 +19,11 @@ import {OpMapper} from '../types';
 
 export const json: OpMapper[] = [
   {
+    'tfOpName': 'DecodeBase64',
+    'category': 'string',
+    'inputs': [{'start': 0, 'name': 'input', 'type': 'tensor'}]
+  },
+  {
     'tfOpName': 'EncodeBase64',
     'category': 'string',
     'inputs': [{'start': 0, 'name': 'input', 'type': 'tensor'}],

--- a/src/operations/types.ts
+++ b/src/operations/types.ts
@@ -25,7 +25,8 @@ export type ParamType = 'number'|'string'|'string[]'|'number[]'|'bool'|'bool[]'|
 export type Category =
     'arithmetic'|'basic_math'|'control'|'convolution'|'custom'|'dynamic'|
     'evaluation'|'image'|'creation'|'graph'|'logical'|'matrices'|
-    'normalization'|'reduction'|'slice_join'|'spectral'|'transformation';
+    'normalization'|'reduction'|'slice_join'|'spectral'|'string'|
+    'transformation';
 
 // For mapping input or attributes of NodeDef into TensorFlow.js op param.
 export declare interface ParamMapper {


### PR DESCRIPTION
the TF implementation of the pix2pix model which fails conversion because of

	`Unsupported Ops: DecodeJpeg, EncodePng, DecodeBase64`

the Open NSFW model also fails conversion with some of the same ops (https://github.com/tensorflow/tfjs/issues/433).

i would like to take the opportunity to implement some of the ops in TensorFlow.js. starting with this pull request for `DecodeBase64` and `EncodeBase64`.

along with this `tfjs-converter` PR, there is a corresponding PR in `tfjs-core` (https://github.com/tensorflow/tfjs-core/pull/1779)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/376)
<!-- Reviewable:end -->
