### PR TITLE
pin tensorflow 2 nightly version to date 06/08

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,5 +2,5 @@ h5py==2.8.0
 keras==2.2.4
 numpy==1.15.1
 six==1.11.0
-tf-nightly-2.0-preview==2.0.0.dev20190608
+tf-nightly-2.0-preview==2.0.0.dev20190605
 tensorflow-hub==0.3.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,5 +2,5 @@ h5py==2.8.0
 keras==2.2.4
 numpy==1.15.1
 six==1.11.0
-tf-nightly-2.0-preview>=2.0.0.dev20190502
+tf-nightly-2.0-preview==2.0.0.dev20190608
 tensorflow-hub==0.3.0


### PR DESCRIPTION
There are couple known issues with TF2 nightly, until 1.14 comes out, let us pin the version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/381)
<!-- Reviewable:end -->
