### PR TITLE
Add support for string weights

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,3 +4,4 @@ numpy==1.15.1
 six==1.11.0
 tf-nightly-2.0-preview==2.0.0.dev20190605
 tensorflow-hub==0.3.0
+chardet==3.0.4

--- a/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -26,7 +26,6 @@ import tensorflow as tf
 from tensorflow.core.protobuf import device_properties_pb2
 from tensorflow.core.protobuf import meta_graph_pb2
 from tensorflow.core.protobuf import config_pb2
-from tensorflow.core.framework import types_pb2
 from tensorflow.python.framework import convert_to_constants
 from tensorflow.python.framework import graph_util
 from tensorflow.python.grappler import cluster as gcluster
@@ -155,15 +154,14 @@ def optimize_graph(func,
                      ', '.join(unsupported))
 
   extract_weights(
-      optimized_graph, output_graph, tf_version, quantization_dtype,
-      skip_op_check)
+      optimized_graph, output_graph, tf_version, quantization_dtype)
   return optimize_graph
 
 
 def extract_weights(graph_def,
                     output_graph,
                     tf_version,
-                    quantization_dtype=None, skip_op_check=False):
+                    quantization_dtype=None):
   """Takes a Python GraphDef object and extract the weights.
 
   Args:
@@ -192,12 +190,7 @@ def extract_weights(graph_def,
       if not isinstance(value, np.ndarray):
         value = np.array(value)
 
-      # TODO(https://github.com/tensorflow/tfjs/issues/1598):
-      # Skip weight serialization of string tensors when we skip op checks.
-      can_skip_weight = (skip_op_check and
-                         const.attr['dtype'].type == types_pb2.DT_STRING)
-      if not can_skip_weight:
-        const_manifest.append({'name': const.name, 'data': value})
+      const_manifest.append({'name': const.name, 'data': value})
 
       # Restore the conditional inputs
       const.input[:] = const_inputs[const.name]

--- a/python/tensorflowjs/read_weights.py
+++ b/python/tensorflowjs/read_weights.py
@@ -73,8 +73,12 @@ def read_weights(weights_manifest, base_path, flatten=False):
 def _deserialize_string_array(
     data_buffer, offset, byte_length, shape, delimiter):
   decoded = data_buffer[offset : offset + byte_length].decode('utf-8')
-  return np.array(
-      decoded.split(delimiter), 'object').reshape(shape)
+  size = np.prod(shape)
+  if size == 0:
+    return np.array([], 'object').reshape(shape)
+  else:
+    return np.array(
+        decoded.split(delimiter), 'object').reshape(shape)
 
 
 def _deserialize_numeric_array(data_buffer, offset, dtype, shape):
@@ -146,7 +150,7 @@ def decode_weights(weights_manifest, data_buffers, flatten=False):
       shape = weight['shape']
       if dtype not in _INPUT_DTYPES:
         raise NotImplementedError('Unsupported data type: %s' % dtype)
-      if dtype == np.object:
+      if weight['dtype'] == 'string':
         weight_bytes = weight['byteLength']
         delimiter = weight['delimiter']
         value = _deserialize_string_array(

--- a/python/tensorflowjs/read_weights.py
+++ b/python/tensorflowjs/read_weights.py
@@ -147,7 +147,7 @@ def decode_weights(weights_manifest, data_buffers, flatten=False):
       if dtype not in _INPUT_DTYPES:
         raise NotImplementedError('Unsupported data type: %s' % dtype)
       if dtype == np.object:
-        weight_bytes = weight['byte_length']
+        weight_bytes = weight['byteLength']
         delimiter = weight['delimiter']
         value = _deserialize_string_array(
             data_buffer, offset, weight_bytes, shape, delimiter)

--- a/python/tensorflowjs/read_weights.py
+++ b/python/tensorflowjs/read_weights.py
@@ -23,7 +23,6 @@ import os
 
 import numpy as np
 from tensorflowjs import quantization
-from tensorflowjs import write_weights
 
 _INPUT_DTYPES = [np.float32, np.int32, np.uint8, np.uint16, np.object]
 
@@ -71,10 +70,11 @@ def read_weights(weights_manifest, base_path, flatten=False):
   return decode_weights(weights_manifest, data_buffers, flatten=flatten)
 
 
-def _deserialize_string_array(data_buffer, offset, byte_length, shape):
+def _deserialize_string_array(
+    data_buffer, offset, byte_length, shape, delimiter):
   decoded = data_buffer[offset : offset + byte_length].decode('utf-8')
   return np.array(
-      decoded.split(write_weights.STRING_DELIMITER), 'object').reshape(shape)
+      decoded.split(delimiter), 'object').reshape(shape)
 
 
 def _deserialize_numeric_array(data_buffer, offset, dtype, shape):
@@ -148,8 +148,9 @@ def decode_weights(weights_manifest, data_buffers, flatten=False):
         raise NotImplementedError('Unsupported data type: %s' % dtype)
       if dtype == np.object:
         weight_bytes = weight['byte_length']
-        value = _deserialize_string_array(data_buffer, offset,
-                                          weight_bytes, shape)
+        delimiter = weight['delimiter']
+        value = _deserialize_string_array(
+            data_buffer, offset, weight_bytes, shape, delimiter)
 
       else:
         value = _deserialize_numeric_array(data_buffer, offset, dtype, shape)

--- a/python/tensorflowjs/read_weights_test.py
+++ b/python/tensorflowjs/read_weights_test.py
@@ -75,7 +75,8 @@ class ReadWeightsTest(unittest.TestCase):
     self.assertEqual('weight1', read_output[0][0]['name'])
     np.testing.assert_array_equal(
         read_output[0][0]['data'],
-        np.array([['test', 'a'], ['b', 'c']], 'object'))
+        np.array([[u'test'.encode('utf-8'), u'a'.encode('utf-8')],
+                  [u'b'.encode('utf-8'), u'c'.encode('utf-8')]], 'object'))
 
 
   def testReadCyrillicStringUnicodeAndEncoded(self):
@@ -103,13 +104,13 @@ class ReadWeightsTest(unittest.TestCase):
     self.assertEqual('weight1', weight1['name'])
     np.testing.assert_array_equal(
         weight1['data'],
-        np.array([u'здраво'], 'object'))
+        np.array([u'здраво'.encode('utf-8')], 'object'))
 
     weight2 = group[1]
     self.assertEqual('weight2', weight2['name'])
     np.testing.assert_array_equal(
         weight2['data'],
-        np.array([u'поздрав'], 'object'))
+        np.array([u'поздрав'.encode('utf-8')], 'object'))
 
   def testReadEastAsianStringUnicodeAndEncoded(self):
     # Each string tensor uses different encoding.
@@ -141,19 +142,19 @@ class ReadWeightsTest(unittest.TestCase):
     self.assertEqual('weight1', weight1['name'])
     np.testing.assert_array_equal(
         weight1['data'],
-        np.array([u'语言处理'], 'object'))
+        np.array([u'语言处理'.encode('utf-8')], 'object'))
 
     weight2 = group[1]
     self.assertEqual('weight2', weight2['name'])
     np.testing.assert_array_equal(
         weight2['data'],
-        np.array([u'语言处理'], 'object'))
+        np.array([u'语言处理'.encode('utf-16')], 'object'))
 
     weight3 = group[2]
     self.assertEqual('weight3', weight3['name'])
     np.testing.assert_array_equal(
         weight3['data'],
-        np.array([u'语言处理'], 'object'))
+        np.array([u'语言处理'.encode('utf-8')], 'object'))
 
   def testReadOneGroupStringWithShards(self):
     groups = [
@@ -172,7 +173,9 @@ class ReadWeightsTest(unittest.TestCase):
     self.assertEqual(1, len(read_output[0]))
     self.assertEqual('weight1', read_output[0][0]['name'])
     np.testing.assert_array_equal(read_output[0][0]['data'],
-                                  np.array(['test', 'a', 'c'], 'object'))
+                                  np.array([u'test'.encode('utf-8'),
+                                            u'a'.encode('utf-8'),
+                                            u'c'.encode('utf-8')], 'object'))
 
   def testReadOneGroupEmptyStrings(self):
     groups = [
@@ -200,7 +203,7 @@ class ReadWeightsTest(unittest.TestCase):
     self.assertEqual('weight1', weight1['name'])
     np.testing.assert_array_equal(
         weight1['data'],
-        np.array(['', ''], 'object'))
+        np.array([u''.encode('utf-8'), u''.encode('utf-8')], 'object'))
 
     weight2 = group[1]
     self.assertEqual('weight2', weight2['name'])

--- a/python/tensorflowjs/read_weights_test.py
+++ b/python/tensorflowjs/read_weights_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -75,6 +76,41 @@ class ReadWeightsTest(unittest.TestCase):
     np.testing.assert_array_equal(
         read_output[0][0]['data'],
         np.array([['test', 'a'], ['b', 'c']], 'object'))
+
+
+  def testReadCyrillicStringUnicodeAndEncoded(self):
+    groups = [
+        [{
+            'name': 'weight1',
+            # String is stored as unicode.
+            'data': np.array([u'здраво'], 'object')
+        },
+        {
+            'name': 'weight2',
+            # String is stored encoded.
+            'data': np.array([u'поздрав'.encode('utf-8')], 'object')
+        }]
+    ]
+
+    manifest = write_weights.write_weights(groups, self._tmp_dir)
+
+    # Read the weights using `read_weights`.
+    read_output = read_weights.read_weights(manifest, self._tmp_dir)
+    self.assertEqual(1, len(read_output))
+    group = read_output[0]
+    self.assertEqual(2, len(group))
+
+    weight1 = group[0]
+    self.assertEqual('weight1', weight1['name'])
+    np.testing.assert_array_equal(
+      weight1['data'],
+      np.array([u'здраво'], 'object'))
+
+    weight2 = group[1]
+    self.assertEqual('weight2', weight2['name'])
+    np.testing.assert_array_equal(
+      weight2['data'],
+      np.array([u'поздрав'], 'object'))
 
   def testReadOneGroupStringWithShards(self):
     groups = [

--- a/python/tensorflowjs/read_weights_test.py
+++ b/python/tensorflowjs/read_weights_test.py
@@ -57,6 +57,43 @@ class ReadWeightsTest(unittest.TestCase):
     self.assertTrue(
         np.allclose(groups[0][0]['data'], read_output[0][0]['data']))
 
+  def testReadOneGroupString(self):
+    groups = [
+        [{
+            'name': 'weight1',
+            'data': np.array([['test', 'a'], ['b', 'c']], 'object')
+        }]
+    ]
+
+    manifest = write_weights.write_weights(groups, self._tmp_dir)
+
+    # Read the weights using `read_weights`.
+    read_output = read_weights.read_weights(manifest, self._tmp_dir)
+    self.assertEqual(1, len(read_output))
+    self.assertEqual(1, len(read_output[0]))
+    self.assertEqual('weight1', read_output[0][0]['name'])
+    np.testing.assert_array_equal(read_output[0][0]['data'],
+                                  np.array([['test', 'a'], ['b', 'c']], 'object'))
+
+  def testReadOneGroupStringWithShards(self):
+    groups = [
+        [{
+            'name': 'weight1',
+            'data': np.array(['test', 'a', 'c'], 'object')
+        }]
+    ]
+
+    manifest = write_weights.write_weights(groups, self._tmp_dir,
+                                           shard_size_bytes=4)
+
+    # Read the weights using `read_weights`.
+    read_output = read_weights.read_weights(manifest, self._tmp_dir)
+    self.assertEqual(1, len(read_output))
+    self.assertEqual(1, len(read_output[0]))
+    self.assertEqual('weight1', read_output[0][0]['name'])
+    np.testing.assert_array_equal(read_output[0][0]['data'],
+                                  np.array(['test', 'a', 'c'], 'object'))
+
   def testReadOneGroupFlattened(self):
     groups = [
         [{

--- a/python/tensorflowjs/read_weights_test.py
+++ b/python/tensorflowjs/read_weights_test.py
@@ -174,6 +174,46 @@ class ReadWeightsTest(unittest.TestCase):
     np.testing.assert_array_equal(read_output[0][0]['data'],
                                   np.array(['test', 'a', 'c'], 'object'))
 
+  def testReadOneGroupEmptyStrings(self):
+    groups = [
+        [{
+            'name': 'weight1',
+            'data': np.array(['', ''], 'object')
+        }, {
+            'name': 'weight2',
+            'data': np.array([], 'object')
+        }, {
+            'name': 'weight3',
+            'data': np.array([[]], 'object')
+        }]
+    ]
+
+    manifest = write_weights.write_weights(groups, self._tmp_dir)
+
+    # Read the weights using `read_weights`.
+    read_output = read_weights.read_weights(manifest, self._tmp_dir)
+    self.assertEqual(1, len(read_output))
+    group = read_output[0]
+    self.assertEqual(3, len(group))
+
+    weight1 = group[0]
+    self.assertEqual('weight1', weight1['name'])
+    np.testing.assert_array_equal(
+        weight1['data'],
+        np.array(['', ''], 'object'))
+
+    weight2 = group[1]
+    self.assertEqual('weight2', weight2['name'])
+    np.testing.assert_array_equal(
+        weight2['data'],
+        np.array([], 'object'))
+
+    weight3 = group[2]
+    self.assertEqual('weight3', weight3['name'])
+    np.testing.assert_array_equal(
+        weight3['data'],
+        np.array([[]], 'object'))
+
   def testReadOneGroupFlattened(self):
     groups = [
         [{

--- a/python/tensorflowjs/read_weights_test.py
+++ b/python/tensorflowjs/read_weights_test.py
@@ -84,8 +84,7 @@ class ReadWeightsTest(unittest.TestCase):
             'name': 'weight1',
             # String is stored as unicode.
             'data': np.array([u'здраво'], 'object')
-        },
-        {
+        }, {
             'name': 'weight2',
             # String is stored encoded.
             'data': np.array([u'поздрав'.encode('utf-8')], 'object')
@@ -103,14 +102,14 @@ class ReadWeightsTest(unittest.TestCase):
     weight1 = group[0]
     self.assertEqual('weight1', weight1['name'])
     np.testing.assert_array_equal(
-      weight1['data'],
-      np.array([u'здраво'], 'object'))
+        weight1['data'],
+        np.array([u'здраво'], 'object'))
 
     weight2 = group[1]
     self.assertEqual('weight2', weight2['name'])
     np.testing.assert_array_equal(
-      weight2['data'],
-      np.array([u'поздрав'], 'object'))
+        weight2['data'],
+        np.array([u'поздрав'], 'object'))
 
   def testReadOneGroupStringWithShards(self):
     groups = [

--- a/python/tensorflowjs/read_weights_test.py
+++ b/python/tensorflowjs/read_weights_test.py
@@ -72,8 +72,9 @@ class ReadWeightsTest(unittest.TestCase):
     self.assertEqual(1, len(read_output))
     self.assertEqual(1, len(read_output[0]))
     self.assertEqual('weight1', read_output[0][0]['name'])
-    np.testing.assert_array_equal(read_output[0][0]['data'],
-                                  np.array([['test', 'a'], ['b', 'c']], 'object'))
+    np.testing.assert_array_equal(
+        read_output[0][0]['data'],
+        np.array([['test', 'a'], ['b', 'c']], 'object'))
 
   def testReadOneGroupStringWithShards(self):
     groups = [

--- a/python/tensorflowjs/read_weights_test.py
+++ b/python/tensorflowjs/read_weights_test.py
@@ -111,6 +111,50 @@ class ReadWeightsTest(unittest.TestCase):
         weight2['data'],
         np.array([u'поздрав'], 'object'))
 
+  def testReadEastAsianStringUnicodeAndEncoded(self):
+    # Each string tensor uses different encoding.
+    groups = [
+        [{
+            'name': 'weight1',
+            # Decoded.
+            'data': np.array([u'语言处理'], 'object')
+        }, {
+            'name': 'weight2',
+            # Encoded as utf-16.
+            'data': np.array([u'语言处理'.encode('utf-16')], 'object')
+        }, {
+            'name': 'weight3',
+            # Encoded as utf-8.
+            'data': np.array([u'语言处理'.encode('utf-8')], 'object')
+        }]
+    ]
+
+    manifest = write_weights.write_weights(groups, self._tmp_dir)
+
+    # Read the weights using `read_weights`.
+    read_output = read_weights.read_weights(manifest, self._tmp_dir)
+    self.assertEqual(1, len(read_output))
+    group = read_output[0]
+    self.assertEqual(3, len(group))
+
+    weight1 = group[0]
+    self.assertEqual('weight1', weight1['name'])
+    np.testing.assert_array_equal(
+        weight1['data'],
+        np.array([u'语言处理'], 'object'))
+
+    weight2 = group[1]
+    self.assertEqual('weight2', weight2['name'])
+    np.testing.assert_array_equal(
+        weight2['data'],
+        np.array([u'语言处理'], 'object'))
+
+    weight3 = group[2]
+    self.assertEqual('weight3', weight3['name'])
+    np.testing.assert_array_equal(
+        weight3['data'],
+        np.array([u'语言处理'], 'object'))
+
   def testReadOneGroupStringWithShards(self):
     groups = [
         [{

--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -21,7 +21,7 @@ import os
 import numpy as np
 
 from tensorflowjs import quantization
-from tensorflowjs.read_weights import STRING_LENGTH_DTYPE
+from tensorflowjs import read_weights
 
 _OUTPUT_DTYPES = [np.float32, np.int32, np.uint8, np.uint16, np.bool, np.object]
 _AUTO_DTYPE_CONVERSION = {
@@ -203,7 +203,8 @@ def _serialize_string_array(data):
 
   for x in strings:
     encoded = x if isinstance(x, bytes) else x.encode('utf-8')
-    length_as_bytes = np.array(len(encoded), STRING_LENGTH_DTYPE).tobytes()
+    length_as_bytes = np.array(len(encoded),
+                               read_weights.STRING_LENGTH_DTYPE).tobytes()
     bytes_writer.write(length_as_bytes)
     bytes_writer.write(encoded)
   bytes_writer.flush()

--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -27,7 +27,7 @@ _AUTO_DTYPE_CONVERSION = {
     np.dtype(np.int64): np.int32}
 
 # Delimiter used in serializing string tensors.
-STRING_DELIMITER = '\x00'
+STRING_DELIMITER = u'\x00'
 
 def write_weights(
     weight_groups, write_dir, shard_size_bytes=1024 * 1024 * 4,
@@ -178,7 +178,11 @@ def _quantize_entry(entry, quantization_dtype):
 
 
 def _serialize_string_array(data):
-  return STRING_DELIMITER.join(data.flatten().tolist()).encode('utf-8')
+  unicode_strings = [
+      x.decode('utf-8') if isinstance(x, bytes) else x
+      for x in data.flatten().tolist()
+  ]
+  return STRING_DELIMITER.join(unicode_strings).encode('utf-8')
 
 def _serialize_numeric_array(data):
   return data.tobytes()

--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -21,7 +21,7 @@ import os
 import numpy as np
 
 from tensorflowjs import quantization
-from read_weights import STRING_LENGTH_DTYPE
+from tensorflowjs.read_weights import STRING_LENGTH_DTYPE
 
 _OUTPUT_DTYPES = [np.float32, np.int32, np.uint8, np.uint16, np.bool, np.object]
 _AUTO_DTYPE_CONVERSION = {

--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -177,12 +177,12 @@ def _quantize_entry(entry, quantization_dtype):
   return quantized_entry
 
 
-def _serialize_string_array(data):
+def _serialize_string_array(data, delimiter):
   unicode_strings = [
       x.decode('utf-8') if isinstance(x, bytes) else x
       for x in data.flatten().tolist()
   ]
-  return STRING_DELIMITER.join(unicode_strings).encode('utf-8')
+  return delimiter.join(unicode_strings).encode('utf-8')
 
 def _serialize_numeric_array(data):
   return data.tobytes()
@@ -210,7 +210,7 @@ def _stack_group_bytes(group):
     data = entry['data']
 
     if data.dtype == np.object:
-      data_bytes = _serialize_string_array(data)
+      data_bytes = _serialize_string_array(data, STRING_DELIMITER)
       entry['byte_length'] = len(data_bytes)
     else:
       data_bytes = _serialize_numeric_array(data)

--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -211,7 +211,7 @@ def _stack_group_bytes(group):
 
     if data.dtype == np.object:
       data_bytes = _serialize_string_array(data, STRING_DELIMITER)
-      entry['byte_length'] = len(data_bytes)
+      entry['byteLength'] = len(data_bytes)
     else:
       data_bytes = _serialize_numeric_array(data)
     group_bytes_writer.write(data_bytes)
@@ -281,7 +281,7 @@ def _get_weights_manifest_for_group(group):
     if dtype == 'object':
       var_manifest['dtype'] = 'string'
       var_manifest['delimiter'] = STRING_DELIMITER
-      var_manifest['byte_length'] = entry['byte_length']
+      var_manifest['byteLength'] = entry['byteLength']
     if is_quantized:
       var_manifest['quantization'] = {
           'min': entry['quantization']['min'],

--- a/python/tensorflowjs/write_weights_test.py
+++ b/python/tensorflowjs/write_weights_test.py
@@ -161,6 +161,18 @@ class TestWriteWeights(unittest.TestCase):
     weights_path = os.path.join(TMP_DIR, 'group1-shard1of1.bin')
     self.assertFalse(os.path.exists(weights_path))
 
+  def test_delimiter_in_string_throws(self):
+    string = 'a' + write_weights.STRING_DELIMITER + 'b'
+    groups = [
+        [{
+            'name': 'weight1',
+            'data': np.array([string], 'object')
+        }]
+    ]
+
+    with self.assertRaises(ValueError):
+      write_weights.write_weights(groups, TMP_DIR)
+
   def test_1_group_1_weight_string_unicode(self):
     groups = [
         [{

--- a/python/tensorflowjs/write_weights_test.py
+++ b/python/tensorflowjs/write_weights_test.py
@@ -99,7 +99,41 @@ class TestWriteWeights(unittest.TestCase):
     groups = [
         [{
             'name': 'weight1',
-            'data': np.array([['hello', 'end'], ['test', 'a']], 'object')
+            'data': np.array([[b'hello', b'end'], [b'test', b'a']], 'object')
+        }]
+    ]
+
+    manifest = write_weights.write_weights(
+        groups, TMP_DIR, shard_size_bytes=4 * 1024 * 1024)
+
+    self.assertTrue(
+        os.path.isfile(os.path.join(TMP_DIR, 'weights_manifest.json')),
+        'weights_manifest.json does not exist')
+
+    self.assertEqual(
+        manifest,
+        [{
+            'paths': ['group1-shard1of1.bin'],
+            'weights': [{
+                'name': 'weight1',
+                'delimiter': '\x00',
+                'byte_length': 16,
+                'shape': [2, 2],
+                'dtype': 'string'
+            }]
+        }])
+
+    weights_path = os.path.join(TMP_DIR, 'group1-shard1of1.bin')
+    with open(weights_path, 'rb') as f:
+      weight_bytes = f.read()
+      self.assertEqual(weight_bytes, b'hello\x00end\x00test\x00a')
+
+
+  def test_1_group_1_weight_string_unicode(self):
+    groups = [
+        [{
+            'name': 'weight1',
+            'data': np.array([[u'hello', u'end'], [u'test', u'a']], 'object')
         }]
     ]
 

--- a/python/tensorflowjs/write_weights_test.py
+++ b/python/tensorflowjs/write_weights_test.py
@@ -307,9 +307,9 @@ class TestWriteWeights(unittest.TestCase):
       np.testing.assert_array_equal(weight1, np.array([1, 2, 3], 'float32'))
 
 
-      self.assertEqual(weight_bytes[12:21], b'hello\x00end')
-      self.assertEqual(weight_bytes[21:33], b'здраво')
-      self.assertEqual(weight_bytes[33:45], b'语言处理')
+      self.assertEqual(weight_bytes[12:21].decode('utf-8'), u'hello\x00end')
+      self.assertEqual(weight_bytes[21:33].decode('utf-8'), u'здраво')
+      self.assertEqual(weight_bytes[33:45].decode('utf-8'), u'语言处理')
 
       weight3 = np.frombuffer(weight_bytes[45:], 'float32')
       np.testing.assert_array_equal(weight3, np.array([4, 5, 6], 'float32'))

--- a/python/tensorflowjs/write_weights_test.py
+++ b/python/tensorflowjs/write_weights_test.py
@@ -128,22 +128,22 @@ class TestWriteWeights(unittest.TestCase):
 
       self.assertEqual(len(weight_bytes), 36)
       # 'здраво'
-      size = np.frombuffer(weight_bytes[:4], 'int32')[0]
+      size = np.frombuffer(weight_bytes[:4], 'uint32')[0]
       self.assertEqual(size, 12) # 6 cyrillic chars (2 bytes each).
       string = weight_bytes[4:16].decode('utf-8')
       self.assertEqual(string, u'здраво')
       # 'end'
-      size = np.frombuffer(weight_bytes[16:20], 'int32')[0]
+      size = np.frombuffer(weight_bytes[16:20], 'uint32')[0]
       self.assertEqual(size, 3) # 3 ascii chars.
       string = weight_bytes[20:23].decode('utf-8')
       self.assertEqual(string, u'end')
       # 'test'
-      size = np.frombuffer(weight_bytes[23:27], 'int32')[0]
+      size = np.frombuffer(weight_bytes[23:27], 'uint32')[0]
       self.assertEqual(size, 4) # 4 ascii chars.
       string = weight_bytes[27:31].decode('utf-8')
       self.assertEqual(string, u'test')
       # 'a'
-      size = np.frombuffer(weight_bytes[31:35], 'int32')[0]
+      size = np.frombuffer(weight_bytes[31:35], 'uint32')[0]
       self.assertEqual(size, 1) # 4 ascii chars.
       string = weight_bytes[35:36].decode('utf-8')
       self.assertEqual(string, u'a')
@@ -179,7 +179,7 @@ class TestWriteWeights(unittest.TestCase):
     with open(weights_path, 'rb') as f:
       weight_bytes = f.read()
       self.assertEqual(len(weight_bytes), 4)
-      size = np.frombuffer(weight_bytes[:4], 'int32')[0]
+      size = np.frombuffer(weight_bytes[:4], 'uint32')[0]
       self.assertEqual(size, 0) # Empty string.
 
   def test_1_group_1_weight_string_unicode(self):
@@ -214,22 +214,22 @@ class TestWriteWeights(unittest.TestCase):
 
       self.assertEqual(len(weight_bytes), 36)
       # 'здраво'
-      size = np.frombuffer(weight_bytes[:4], 'int32')[0]
+      size = np.frombuffer(weight_bytes[:4], 'uint32')[0]
       self.assertEqual(size, 12) # 6 cyrillic chars (2 bytes each).
       string = weight_bytes[4:16].decode('utf-8')
       self.assertEqual(string, u'здраво')
       # 'end'
-      size = np.frombuffer(weight_bytes[16:20], 'int32')[0]
+      size = np.frombuffer(weight_bytes[16:20], 'uint32')[0]
       self.assertEqual(size, 3) # 3 ascii chars.
       string = weight_bytes[20:23].decode('utf-8')
       self.assertEqual(string, u'end')
       # 'test'
-      size = np.frombuffer(weight_bytes[23:27], 'int32')[0]
+      size = np.frombuffer(weight_bytes[23:27], 'uint32')[0]
       self.assertEqual(size, 4) # 4 ascii chars.
       string = weight_bytes[27:31].decode('utf-8')
       self.assertEqual(string, u'test')
       # 'a'
-      size = np.frombuffer(weight_bytes[31:35], 'int32')[0]
+      size = np.frombuffer(weight_bytes[31:35], 'uint32')[0]
       self.assertEqual(size, 1) # 4 ascii chars.
       string = weight_bytes[35:36].decode('utf-8')
       self.assertEqual(string, u'a')
@@ -274,7 +274,7 @@ class TestWriteWeights(unittest.TestCase):
       weight_bytes += f.read()
 
     self.assertEqual(len(weight_bytes), 14)
-    size = np.frombuffer(weight_bytes[:4], 'int32')[0]
+    size = np.frombuffer(weight_bytes[:4], 'uint32')[0]
     self.assertEqual(size, 10) # 10 ascii chars.
     string = weight_bytes[4:14].decode('utf-8')
     self.assertEqual(string, u'helloworld')
@@ -345,25 +345,25 @@ class TestWriteWeights(unittest.TestCase):
       np.testing.assert_array_equal(weight1, np.array([1, 2, 3], 'float32'))
 
       # 'hello'
-      size = np.frombuffer(weight_bytes[12:16], 'int32')[0]
+      size = np.frombuffer(weight_bytes[12:16], 'uint32')[0]
       self.assertEqual(size, 12) # 5 ascii chars in utf-16.
       string = weight_bytes[16:28].decode('utf-16')
       self.assertEqual(string, u'hello')
 
       # 'end'
-      size = np.frombuffer(weight_bytes[28:32], 'int32')[0]
+      size = np.frombuffer(weight_bytes[28:32], 'uint32')[0]
       self.assertEqual(size, 8) # 3 ascii chars in utf-16.
       string = weight_bytes[32:40].decode('utf-16')
       self.assertEqual(string, u'end')
 
       # 'здраво'
-      size = np.frombuffer(weight_bytes[40:44], 'int32')[0]
+      size = np.frombuffer(weight_bytes[40:44], 'uint32')[0]
       self.assertEqual(size, 6) # 6 cyrillic chars in windows-1251.
       string = weight_bytes[44:50].decode('windows-1251')
       self.assertEqual(string, u'здраво')
 
       # '语言处理'
-      size = np.frombuffer(weight_bytes[50:54], 'int32')[0]
+      size = np.frombuffer(weight_bytes[50:54], 'uint32')[0]
       self.assertEqual(size, 12) # 4 east asian chars in utf-8.
       string = weight_bytes[54:66].decode('utf-8')
       self.assertEqual(string, u'语言处理')

--- a/python/tensorflowjs/write_weights_test.py
+++ b/python/tensorflowjs/write_weights_test.py
@@ -129,22 +129,22 @@ class TestWriteWeights(unittest.TestCase):
       self.assertEqual(len(weight_bytes), 36)
       # 'здраво'
       size = np.frombuffer(weight_bytes[:4], 'uint32')[0]
-      self.assertEqual(size, 12) # 6 cyrillic chars (2 bytes each).
+      self.assertEqual(size, 12)  # 6 cyrillic chars (2 bytes each).
       string = weight_bytes[4:16].decode('utf-8')
       self.assertEqual(string, u'здраво')
       # 'end'
       size = np.frombuffer(weight_bytes[16:20], 'uint32')[0]
-      self.assertEqual(size, 3) # 3 ascii chars.
+      self.assertEqual(size, 3)  # 3 ascii chars.
       string = weight_bytes[20:23].decode('utf-8')
       self.assertEqual(string, u'end')
       # 'test'
       size = np.frombuffer(weight_bytes[23:27], 'uint32')[0]
-      self.assertEqual(size, 4) # 4 ascii chars.
+      self.assertEqual(size, 4)  # 4 ascii chars.
       string = weight_bytes[27:31].decode('utf-8')
       self.assertEqual(string, u'test')
       # 'a'
       size = np.frombuffer(weight_bytes[31:35], 'uint32')[0]
-      self.assertEqual(size, 1) # 4 ascii chars.
+      self.assertEqual(size, 1)  # 4 ascii chars.
       string = weight_bytes[35:36].decode('utf-8')
       self.assertEqual(string, u'a')
 
@@ -180,7 +180,7 @@ class TestWriteWeights(unittest.TestCase):
       weight_bytes = f.read()
       self.assertEqual(len(weight_bytes), 4)
       size = np.frombuffer(weight_bytes[:4], 'uint32')[0]
-      self.assertEqual(size, 0) # Empty string.
+      self.assertEqual(size, 0)  # Empty string.
 
   def test_1_group_1_weight_string_unicode(self):
     groups = [
@@ -215,22 +215,22 @@ class TestWriteWeights(unittest.TestCase):
       self.assertEqual(len(weight_bytes), 36)
       # 'здраво'
       size = np.frombuffer(weight_bytes[:4], 'uint32')[0]
-      self.assertEqual(size, 12) # 6 cyrillic chars (2 bytes each).
+      self.assertEqual(size, 12)  # 6 cyrillic chars (2 bytes each).
       string = weight_bytes[4:16].decode('utf-8')
       self.assertEqual(string, u'здраво')
       # 'end'
       size = np.frombuffer(weight_bytes[16:20], 'uint32')[0]
-      self.assertEqual(size, 3) # 3 ascii chars.
+      self.assertEqual(size, 3)  # 3 ascii chars.
       string = weight_bytes[20:23].decode('utf-8')
       self.assertEqual(string, u'end')
       # 'test'
       size = np.frombuffer(weight_bytes[23:27], 'uint32')[0]
-      self.assertEqual(size, 4) # 4 ascii chars.
+      self.assertEqual(size, 4)  # 4 ascii chars.
       string = weight_bytes[27:31].decode('utf-8')
       self.assertEqual(string, u'test')
       # 'a'
       size = np.frombuffer(weight_bytes[31:35], 'uint32')[0]
-      self.assertEqual(size, 1) # 4 ascii chars.
+      self.assertEqual(size, 1)  # 4 ascii chars.
       string = weight_bytes[35:36].decode('utf-8')
       self.assertEqual(string, u'a')
 
@@ -275,7 +275,7 @@ class TestWriteWeights(unittest.TestCase):
 
     self.assertEqual(len(weight_bytes), 14)
     size = np.frombuffer(weight_bytes[:4], 'uint32')[0]
-    self.assertEqual(size, 10) # 10 ascii chars.
+    self.assertEqual(size, 10)  # 10 ascii chars.
     string = weight_bytes[4:14].decode('utf-8')
     self.assertEqual(string, u'helloworld')
 
@@ -346,25 +346,25 @@ class TestWriteWeights(unittest.TestCase):
 
       # 'hello'
       size = np.frombuffer(weight_bytes[12:16], 'uint32')[0]
-      self.assertEqual(size, 12) # 5 ascii chars in utf-16.
+      self.assertEqual(size, 12)  # 5 ascii chars in utf-16.
       string = weight_bytes[16:28].decode('utf-16')
       self.assertEqual(string, u'hello')
 
       # 'end'
       size = np.frombuffer(weight_bytes[28:32], 'uint32')[0]
-      self.assertEqual(size, 8) # 3 ascii chars in utf-16.
+      self.assertEqual(size, 8)  # 3 ascii chars in utf-16.
       string = weight_bytes[32:40].decode('utf-16')
       self.assertEqual(string, u'end')
 
       # 'здраво'
       size = np.frombuffer(weight_bytes[40:44], 'uint32')[0]
-      self.assertEqual(size, 6) # 6 cyrillic chars in windows-1251.
+      self.assertEqual(size, 6)  # 6 cyrillic chars in windows-1251.
       string = weight_bytes[44:50].decode('windows-1251')
       self.assertEqual(string, u'здраво')
 
       # '语言处理'
       size = np.frombuffer(weight_bytes[50:54], 'uint32')[0]
-      self.assertEqual(size, 12) # 4 east asian chars in utf-8.
+      self.assertEqual(size, 12)  # 4 east asian chars in utf-8.
       string = weight_bytes[54:66].decode('utf-8')
       self.assertEqual(string, u'语言处理')
 

--- a/src/executor/graph_executor.ts
+++ b/src/executor/graph_executor.ts
@@ -237,6 +237,7 @@ export class GraphExecutor {
       Promise<Tensor[]> {
     this.checkInputs(inputs);
     this.checkInputShapeAndType(inputs);
+    this.checkOutputs(outputs);
     const tensorArrayMap: TensorArrayMap = {};
     const context = new ExecutionContext(this._weightMap, tensorArrayMap);
     // Graph with control flow op requires runtime evaluation of the execution


### PR DESCRIPTION
Allow serialization and deserialization of string weights in the binary weights format.

This is needed to enable execution of AutoML models, which store the vocab as a weight (`Const` of dtype `string`).

Corresponding change in tfjs-core: https://github.com/tensorflow/tfjs-core/pull/1816

Fixes https://github.com/tensorflow/tfjs/issues/1598

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/386)
<!-- Reviewable:end -->
