### PR TITLE
Enable conversion of AutoML Object Detection Model

### DIFF
--- a/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -24,7 +24,6 @@ import os
 import numpy as np
 import tensorflow as tf
 from tensorflow.core.protobuf import device_properties_pb2
-from tensorflow.core.protobuf import meta_graph_pb2
 from tensorflow.core.protobuf import config_pb2
 from tensorflow.python.framework import convert_to_constants
 from tensorflow.python.grappler import cluster as gcluster
@@ -47,7 +46,7 @@ CLEARED_TENSOR_FIELDS = (
 
 _HUB_V1_MODULE_PB = "tfhub_module.pb"
 
-def load_graph(graph_filename, output_node_names):
+def load_graph(graph_filename):
   """Loads GraphDef. Returns Python Graph object.
 
   Args:
@@ -60,10 +59,6 @@ def load_graph(graph_filename, output_node_names):
   with tf.Graph().as_default() as graph:
     # Set name to empty to avoid using the default name 'import'.
     tf.import_graph_def(graph_def, name='')
-
-  for node in output_node_names.split(','):
-    graph.add_to_collection('train_op',
-                            graph.get_operation_by_name(node.strip()))
 
   return graph
 
@@ -100,27 +95,26 @@ def validate(nodes, skip_op_check, strip_debug_ops):
   not_supported = {x.op for x in [x for x in nodes if x.op not in names]}
   return not_supported
 
-def optimize_graph(func,
-                   output_graph,
-                   tf_version,
-                   quantization_dtype=None,
-                   skip_op_check=False,
-                   strip_debug_ops=False,
-                   graph=None):
+def optimize_graph(graph, output_node_names, output_graph, tf_version,
+                   quantization_dtype=None, skip_op_check=False,
+                   strip_debug_ops=False):
   """Takes a Python Graph object and optimizes the graph.
 
   Args:
-    func: ConcreteFunction TensorFlow function def.
+    graph: The frozen graph to optimize.
+    output_node_names: List of output node names.
+    output_graph: The location of the output graph.
     tf_version: Tensorflow version of the input graph.
     quantization_dtype: An optional numpy dtype to quantize weights to for
       compression. Only np.uint8 and np.uint16 are supported.
     skip_op_check: Bool whether to skip the op check.
     strip_debug_ops: Bool whether to strip debug ops.
-    graph_def: tf.GraphDef TensorFlow GraphDef proto object, which represents
-      the model topology.
   """
-  if graph is None:
-    graph = func.graph
+
+  # Add a collection 'train_op' so that Grappler knows the outputs.
+  for output in output_node_names:
+    graph.add_to_collection('train_op', graph.get_operation_by_name(output))
+
   graph_def = graph.as_graph_def()
   unsupported = validate(graph_def.node, skip_op_check,
                          strip_debug_ops)
@@ -138,13 +132,6 @@ def optimize_graph(func,
     rewriter_config.optimizers.insert(0, 'debug_stripper')
   meta_graph = export_meta_graph(
       graph_def=graph_def, graph=graph)
-
-  # Add a collection 'train_op' so that Grappler knows the outputs.
-  fetch_collection = meta_graph_pb2.CollectionDef()
-  if func is not None:
-    for array in func.inputs + func.outputs:
-      fetch_collection.node_list.value.append(array.name)
-    meta_graph.collection_def["train_op"].CopyFrom(fetch_collection)
 
   optimized_graph = tf_optimizer.OptimizeGraph(
       config, meta_graph, cluster=get_cluster())
@@ -249,6 +236,20 @@ def _check_signature_in_model(saved_model, signature_name):
                                             saved_model.signatures.keys()))
 
 
+def _freeze_saved_model_v1(graph, output_node_names):
+  frozen_graph_def = tf.compat.v1.graph_util.convert_variables_to_constants(
+      tf.compat.v1.Session(), graph.as_graph_def(), output_node_names)
+
+  frozen_graph = tf.Graph()
+  with frozen_graph.as_default():
+    tf.import_graph_def(frozen_graph_def, name='')
+
+  return frozen_graph
+
+def _freeze_saved_model_v2(concrete_func):
+  return convert_to_constants.convert_variables_to_constants_v2(
+      concrete_func).graph
+
 def convert_tf_saved_model(saved_model_dir,
                            output_dir, signature_def='serving_default',
                            saved_model_tags='serve',
@@ -289,34 +290,24 @@ def convert_tf_saved_model(saved_model_dir,
   _check_signature_in_model(model, signature_def)
 
   concrete_func = model.signatures[signature_def]
+  output_node_names = []
+  for output_tensor in concrete_func.outputs:
+    output_node_names.append(output_tensor.name.split(':')[0])
+
+  # TensorFlow doesn't encode the saved model version in the graph in a reliable
+  # way. Try to freeze the graph using V2 utils. If that fails, freeze the
+  # graph using V1 utils.
   try:
-    frozen_func = convert_to_constants.convert_variables_to_constants_v2(
-      concrete_func)
+    frozen_graph = _freeze_saved_model_v2(concrete_func)
+  except ValueError:
+    frozen_graph = _freeze_saved_model_v1(
+        concrete_func.graph, output_node_names)
 
-    optimize_graph(frozen_func, output_graph, model.tensorflow_version,
+  optimize_graph(frozen_graph, output_node_names, output_graph,
+                 model.tensorflow_version,
                  quantization_dtype=quantization_dtype,
-                 skip_op_check=skip_op_check, strip_debug_ops=strip_debug_ops)
-  except:
-    graph_def = concrete_func.graph.as_graph_def()
-    output_node_names = []
-    for output_tensor in concrete_func.outputs:
-      output_node_names.append(output_tensor.name.split(':')[0])
-
-    frozen_graph_def = tf.compat.v1.graph_util.convert_variables_to_constants(
-      tf.compat.v1.Session(), graph_def, output_node_names)
-
-    frozen_graph = tf.Graph()
-    with frozen_graph.as_default():
-      tf.import_graph_def(frozen_graph_def, name='')
-
-    for output in output_node_names:
-      frozen_graph.add_to_collection('train_op',
-                            frozen_graph.get_operation_by_name(output))
-    optimize_graph(None, output_graph, model.tensorflow_version,
-                  quantization_dtype=quantization_dtype,
-                  skip_op_check=skip_op_check,
-                  strip_debug_ops=strip_debug_ops,
-                  graph=frozen_graph)
+                 skip_op_check=skip_op_check,
+                 strip_debug_ops=strip_debug_ops)
 
 def load_and_initialize_hub_module(module_path, signature='default'):
   """Loads graph of a TF-Hub module and initializes it into a session.
@@ -412,11 +403,10 @@ def convert_tf_hub_module_v1(module_path, output_dir,
     with tf.compat.v1.gfile.GFile(frozen_file, 'wb') as f:
       f.write(frozen_graph_def.SerializeToString())
 
-    graph = load_graph(frozen_file, ','.join(output_node_names))
-    optimize_graph(None, output_graph, tf.__version__,
-                   quantization_dtype=quantization_dtype,
-                   skip_op_check=skip_op_check, strip_debug_ops=strip_debug_ops,
-                   graph=graph)
+    frozen_graph = load_graph(frozen_file)
+    optimize_graph(frozen_graph, output_node_names, output_graph,
+                   tf.__version__, quantization_dtype=quantization_dtype,
+                   skip_op_check=skip_op_check, strip_debug_ops=strip_debug_ops)
   finally:
     # Clean up the temp files.
     if os.path.exists(frozen_file):

--- a/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -299,7 +299,7 @@ def convert_tf_saved_model(saved_model_dir,
   # graph using V1 utils.
   try:
     frozen_graph = _freeze_saved_model_v2(concrete_func)
-  except ValueError:
+  except Exception:
     frozen_graph = _freeze_saved_model_v1(
         concrete_func.graph, output_node_names)
 

--- a/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
+++ b/python/tensorflowjs/converters/tf_saved_model_conversion_v2.py
@@ -299,7 +299,7 @@ def convert_tf_saved_model(saved_model_dir,
   # graph using V1 utils.
   try:
     frozen_graph = _freeze_saved_model_v2(concrete_func)
-  except Exception:
+  except BaseException:
     frozen_graph = _freeze_saved_model_v1(
         concrete_func.graph, output_node_names)
 

--- a/python/tensorflowjs/read_weights_test.py
+++ b/python/tensorflowjs/read_weights_test.py
@@ -89,6 +89,10 @@ class ReadWeightsTest(unittest.TestCase):
             'name': 'weight2',
             # String is stored encoded.
             'data': np.array([u'поздрав'.encode('utf-8')], 'object')
+        }, {
+            'name': 'weight3',
+            # Let np choose the dtype (string or bytes depending on py version).
+            'data': np.array([u'здраво'.encode('utf-8')])
         }]
     ]
 
@@ -98,7 +102,7 @@ class ReadWeightsTest(unittest.TestCase):
     read_output = read_weights.read_weights(manifest, self._tmp_dir)
     self.assertEqual(1, len(read_output))
     group = read_output[0]
-    self.assertEqual(2, len(group))
+    self.assertEqual(3, len(group))
 
     weight1 = group[0]
     self.assertEqual('weight1', weight1['name'])
@@ -111,6 +115,12 @@ class ReadWeightsTest(unittest.TestCase):
     np.testing.assert_array_equal(
         weight2['data'],
         np.array([u'поздрав'.encode('utf-8')], 'object'))
+
+    weight3 = group[2]
+    self.assertEqual('weight3', weight3['name'])
+    np.testing.assert_array_equal(
+        weight3['data'],
+        np.array([u'здраво'.encode('utf-8')]))
 
   def testReadEastAsianStringUnicodeAndEncoded(self):
     # Each string tensor uses different encoding.

--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -342,7 +342,7 @@ def _assert_no_duplicate_weight_names(weight_groups):
 def _auto_convert_weight_entry(entry):
   data = entry['data']
   if data.dtype in _AUTO_DTYPE_CONVERSION:
-    entry['data'] = _AUTO_DTYPE_CONVERSION[data.dtype](data)
+    entry['data'] = data.astype(_AUTO_DTYPE_CONVERSION[data.dtype])
     print('weight ' + entry['name'] + ' with shape ' + str(data.shape) +
           ' and dtype ' + data.dtype.name + ' was auto converted to the type ' +
           np.dtype(_AUTO_DTYPE_CONVERSION[data.dtype]).name)

--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -357,7 +357,9 @@ def _assert_valid_weight_entry(entry):
   name = entry['name']
   data = entry['data']
 
-  if data.dtype.name.startswith('string'):
+  # String tensors can be backed by different numpy dtypes, thus we consolidate
+  # to a single 'np.object' dtype.
+  if data.dtype.name.startswith('str') or data.dtype.name.startswith('bytes'):
     data = data.astype(np.object)
 
   if not (data.dtype in _OUTPUT_DTYPES or data.dtype in _AUTO_DTYPE_CONVERSION):

--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -357,6 +357,9 @@ def _assert_valid_weight_entry(entry):
   name = entry['name']
   data = entry['data']
 
+  if data.dtype.name.startswith('string'):
+    data = data.astype(np.object)
+
   if not (data.dtype in _OUTPUT_DTYPES or data.dtype in _AUTO_DTYPE_CONVERSION):
     raise ValueError('Error dumping weight ' + name + ', dtype ' +
                      data.dtype.name + ' not supported.')

--- a/python/tensorflowjs/write_weights.py
+++ b/python/tensorflowjs/write_weights.py
@@ -361,6 +361,8 @@ def _assert_valid_weight_entry(entry):
   # to a single 'np.object' dtype.
   if data.dtype.name.startswith('str') or data.dtype.name.startswith('bytes'):
     data = data.astype(np.object)
+    entry['data'] = data
+
 
   if not (data.dtype in _OUTPUT_DTYPES or data.dtype in _AUTO_DTYPE_CONVERSION):
     raise ValueError('Error dumping weight ' + name + ', dtype ' +


### PR DESCRIPTION
Fix conversion of AutoML Object detection edge model.

After this change, the converter becomes more robust by trying to freeze a V2 graph, and if that fails, it will try to freeze V1 graph.

Also improve support for serializing string tensors, which can be backed by a `np.array` of dtype `"object"|"string"|"bytes"`

BUG

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-converter/401)
<!-- Reviewable:end -->
